### PR TITLE
chore: update release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance Improvements"},
+    {"type": "revert", "section": "Reverts"},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous", "hidden": true},
+    {"type": "refactor", "section": "Code Refactoring", "hidden": true},
+    {"type": "style", "section": "Styles", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "ci", "section": "CI/CD", "hidden": true},
+    {"type": "build", "section": "Build System", "hidden": true}
+  ],
   "packages": {
     ".": {
       "package-name": "schlock",


### PR DESCRIPTION
- ensure non-release commits don't trigger PRs by explicitly adding hidden:true
