### PR TITLE
fix(security): close P0 bypass vectors from security review

### DIFF
--- a/data/rules/10_development_workflows.yaml
+++ b/data/rules/10_development_workflows.yaml
@@ -97,6 +97,34 @@ rules:
       - "Review build scripts before running"
       - "Install to user directory with PREFIX"
 
+  - name: homebrew_tap_install
+    description: Installing from third-party Homebrew taps executes code from arbitrary GitHub repos
+    risk_level: HIGH
+    patterns:
+      # brew install from tap (user/repo/formula format)
+      # Character class includes dots for GitHub usernames like "user.org" (FINDING-003)
+      - 'brew\s+install\s+[^;|&]*[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+'
+      - 'brew\s+install\s+[^;|&]*--cask\s+[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+'
+      # brew tap adds arbitrary GitHub repos as package sources
+      - 'brew\s+tap\s+[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+'
+    alternatives:
+      - "Verify the tap repository before adding"
+      - "Use official Homebrew formulae when available"
+      - "Review the formula source code"
+
+  - name: homebrew_install
+    description: Homebrew install downloads and executes install scripts
+    risk_level: MEDIUM
+    patterns:
+      # Regular brew install (official formulae)
+      - 'brew\s+install\s+(?![^;|&]*[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)'
+      - 'brew\s+install\s+--cask\s+(?![^;|&]*[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)'
+      # brew upgrade can change binaries
+      - 'brew\s+upgrade'
+    alternatives:
+      - "Review what will be installed with 'brew info'"
+      - "Check formula source with 'brew cat'"
+
   - name: package_installation_system
     description: System-wide package installation
     risk_level: MEDIUM


### PR DESCRIPTION
## Summary

Closes critical security bypass vectors identified during security review of the AST-based pipeline detection system.

### Changes

**AST-based Pipeline Detection** (`parser.py`)
- Added `_detect_dangerous_pipelines()` method using bashlex AST analysis
- Immune to obfuscation: env var prefixes, redirects, full paths, whitespace tricks
- Integrated into existing `has_dangerous_constructs()` flow

**FINDING-001: Missing Download Tools**
- Added: `ftp`, `tftp`, `sftp`, `scp`, `rsync`, `git`, `svn`, `hg`

**FINDING-002: Missing Interpreters** (P0 Critical)
- Added: `env`, `xargs`, `lua`, `php`, `pwsh`, `Rscript`, `tclsh`, `gawk`, `busybox`
- **Critical fix**: `curl url | env bash` was a complete bypass

**FINDING-003: Homebrew Supply Chain**
- Added `homebrew_tap_install` rule (HIGH) for third-party taps
- Added `homebrew_install` rule (MEDIUM) for official formulae  
- Fixed regex to match dots in GitHub usernames (`user.org/tap`)

### Test Coverage

- 9 new tests in `TestSecurityReviewFindings` and `TestHomebrewSupplyChain`
- 941 tests passing, 90% coverage

## Test Plan

- [x] Verify `curl url | env bash` is BLOCKED
- [x] Verify `curl url | VAR=x sh` is BLOCKED (original issue)
- [x] Verify `brew install user/tap/formula` is HIGH risk
- [x] Verify `brew install user.org/tap/formula` is HIGH risk (dot bypass)
- [x] Verify safe pipelines (`curl | jq`) remain ALLOWED
- [x] Full test suite passes (941 tests)