### PR TITLE
chore: fix release process version sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "schlock",
       "source": "./",
       "description": "LLM command safety validator. Blocks dangerous bash commands and Claude advertising spam.",
-      "version": "0.1.0",
+      "version": "0.2.4",
       "author": {
         "name": "27B.io"
       },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,3 +25,28 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+
+      # Sync uv.lock on the release PR branch (before merge)
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.pr }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+
+      - uses: astral-sh/setup-uv@v4
+        if: ${{ steps.release.outputs.pr }}
+
+      - name: Sync uv.lock on release PR
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          set -e
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: sync uv.lock"
+            git push
+          fi

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,11 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
         }
       ]
     }

--- a/uv.lock
+++ b/uv.lock
@@ -500,7 +500,7 @@ wheels = [
 
 [[package]]
 name = "schlock"
-version = "0.1.0"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "bashlex" },


### PR DESCRIPTION
## Summary
- Add marketplace.json to release-please extra-files
- Add post-release uv.lock sync to workflow
- Fix marketplace.json version drift (0.1.0 → 0.2.4)
- Sync uv.lock with pyproject.toml

## Why
Release-please wasn't updating marketplace.json version, and uv.lock would drift after each release since pyproject.toml version changes but uv.lock wasn't regenerated.

## Test plan
- [x] Verified uv.lock is in sync
- [x] release-please config valid JSON