### PR TITLE
chore: sync marketplace.json version to 0.2.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "schlock",
       "source": "./",
       "description": "LLM command safety validator. Blocks dangerous bash commands and Claude advertising spam.",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "author": {
         "name": "27B.io"
       },


### PR DESCRIPTION
## Summary
- One-time fixup to sync marketplace.json version with release 0.2.5

## Context
PR #36 (which added marketplace.json to release-please `extra-files`) was merged **after** PR #35 (0.2.5 release) was already created by release-please. 

Future releases will update this file automatically via the jsonpath `$.plugins[0].version`.

## Test plan
- [x] Verify version now shows 0.2.5