### PR TITLE
fix: avoid --rm matching protect_system_files

### DIFF
--- a/data/rules/08_system_modification.yaml
+++ b/data/rules/08_system_modification.yaml
@@ -7,7 +7,8 @@ rules:
   - name: protect_system_files
     description: Prevent modifications to system files
     risk_level: BLOCKED
-    patterns: ['\b(rm|mv|cp)\s+.{0,200}/(etc|sys|proc|boot|sbin|dev)/', '>\s*/(etc|sys|proc|boot|sbin)/', 'rm\s+/sbin/init', 'rm\s+/dev/', 'chmod.{0,100}/(sbin|dev|usr/lib/systemd)/', 'chmod\s+000\s+/usr/', 'mknod\s+/dev/']
+    # Note: Using (?:^|[\s;&|]) instead of \b to avoid false positives on flags like --rm
+    patterns: ['(?:^|[\s;&|])(rm|mv|cp)\s+.{0,200}/(etc|sys|proc|boot|sbin|dev)/', '>\s*/(etc|sys|proc|boot|sbin)/', '>\s*/dev/(?!null\b)', '(?:^|[\s;&|])rm\s+/sbin/init', '(?:^|[\s;&|])rm\s+/dev/', '(?:^|[\s;&|])chmod.{0,100}/(sbin|dev|usr/lib/systemd)/', '(?:^|[\s;&|])chmod\s+000\s+/usr/', '(?:^|[\s;&|])mknod\s+/dev/']
     alternatives: ["Use configuration management tools", "Request system administrator access"]
 
   - name: recursive_permission_system_dirs

--- a/tests/test_dangerous_commands.py
+++ b/tests/test_dangerous_commands.py
@@ -612,6 +612,18 @@ class TestP0ContainerEscape:
         result = validate_command("docker run ubuntu echo hello", config_path=safety_rules_path)
         assert result.allowed
 
+    def test_docker_rm_flag_not_false_positive(self, safety_rules_path):
+        """Docker --rm flag should not trigger protect_system_files rule.
+
+        Regression test for false positive where --rm matched as rm command
+        and 2>/dev/null matched as /dev/ path.
+        """
+        # This was incorrectly blocked as "Prevent modifications to system files"
+        cmd = "docker run --rm node:24-alpine npm --version 2>/dev/null"
+        result = validate_command(cmd, config_path=safety_rules_path)
+        assert result.allowed, f"docker --rm should be allowed, got: {result.message}"
+        assert "protect_system_files" not in result.matched_rules
+
 
 class TestP0LogTampering:
     """Test P0: log_tampering rule."""


### PR DESCRIPTION
Prevent false positive where docker --rm and 2>/dev/null triggered the rm /dev/ system-file rule. Adds regression test.
