### PR TITLE
feat: support custom whitelist patterns in user config yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Command/process substitution (`$(cmd)`, `<(cmd)`) requires special handling beca
 
 **Rule Overrides**: Per-rule and per-category overrides via `rule_overrides` and `category_overrides` YAML keys. BLOCKED rules cannot be downgraded or disabled (security floor).
 
+**Command Whitelist**: User-level config (`~/.config/schlock/config.yaml`) supports `whitelist:` — a list of regex patterns that bypass ALL rules including BLOCKED. Project-level config cannot define whitelist patterns (privilege escalation risk). See `docs/CONFIGURATION.md`.
+
 **Self-Protection**: Three-layer defense prevents LLM agents from modifying schlock config:
 1. YAML rules (`14_self_protection.yaml`, BLOCKED) — can't be overridden
 2. Hardcoded validator check (`_check_self_protection`) — independent of YAML rules

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -102,8 +102,55 @@ Overrides are applied in this order (later wins):
 #### Security Constraints
 
 - **BLOCKED rules cannot be downgraded or disabled** — this is a non-negotiable security floor
+- **Whitelist patterns are user-level config only** — project-level config cannot define whitelist patterns (see below)
 - Invalid overrides log warnings and are skipped (graceful degradation)
 - Unknown rule or category names log warnings and are skipped
+
+### Command Whitelist
+
+For commands that are caught by rules you can't override (e.g., BLOCKED-level rules), you can define whitelist patterns in your **user-level** config. Whitelisted commands bypass all rules including BLOCKED.
+
+```yaml
+# ~/.config/schlock/config.yaml (user-level ONLY)
+whitelist:
+  - ^gcloud\s+config\s+get-value\s+project$
+  - '^"?/home/\w+/\.claude/plugins/.*\.sh'
+```
+
+#### How It Works
+
+- Patterns are regex, matched against the start of the command string (like `re.match()`)
+- A match bypasses ALL rule checks — the command is allowed unconditionally
+- User whitelist patterns merge with built-in whitelist patterns from the plugin
+- Invalid regex patterns are skipped with a warning (won't crash the validator)
+
+#### Writing Good Patterns
+
+Whitelist patterns use prefix matching (anchored at the start, not the end). Write patterns specific enough to avoid unintended matches:
+
+```yaml
+# GOOD: Specific command with anchored end
+whitelist:
+  - ^gcloud\s+config\s+get-value\s+project$
+
+# GOOD: Specific script path
+whitelist:
+  - '^/home/myuser/\.claude/plugins/setup\.sh\b'
+
+# BAD: Too broad — matches ALL gcloud commands including dangerous ones
+whitelist:
+  - ^gcloud
+```
+
+Use `$` at the end when you want to match the exact command. Without `$`, the pattern matches any command that starts with the pattern text.
+
+#### Security: User-Level Only
+
+Whitelist patterns are **only** loaded from `~/.config/schlock/config.yaml`. Project-level config (`.claude/hooks/schlock-config.yaml`) cannot define whitelist patterns.
+
+**Why?** Whitelist bypasses ALL rules including BLOCKED. If project-level config could define whitelist patterns, a malicious repository could include a `schlock-config.yaml` that whitelists dangerous commands. Since project config is auto-loaded when you `cd` into a repo, this would be a privilege escalation attack.
+
+Rule and category overrides are safe at the project level because `apply_overrides()` enforces a BLOCKED floor — you can't downgrade BLOCKED rules. Whitelist has no such floor by design (bypassing BLOCKED is its purpose), so it's restricted to user-level config.
 
 #### Available Categories
 

--- a/src/schlock/core/rules.py
+++ b/src/schlock/core/rules.py
@@ -485,7 +485,9 @@ class RuleEngine:
         """
         for pattern_str in patterns:
             try:
-                compiled = re.compile(pattern_str, re.MULTILINE)
+                # No re.MULTILINE: whitelist uses match() which anchors at start.
+                # MULTILINE would change $ to match at line boundaries, not string end.
+                compiled = re.compile(pattern_str)
                 self.whitelist_patterns.append(compiled)
             except re.error as e:
                 raise ConfigurationError(

--- a/src/schlock/core/validator.py
+++ b/src/schlock/core/validator.py
@@ -142,33 +142,67 @@ class ValidationResult:
     matched_rules: list[str] = field(default_factory=list)
 
 
-def _load_rule_overrides() -> tuple[dict, dict]:
-    """Load rule and category overrides from config files.
+def _extract_whitelist_patterns(data: dict, config_path: Path, is_user_level: bool) -> list[str]:
+    """Extract whitelist patterns from a parsed config file.
+
+    SECURITY: Only user-level config may define whitelist patterns.
+    Project-level config is rejected with a warning.
+    """
+    if not is_user_level:
+        if data.get("whitelist"):
+            logger.warning(
+                f"Ignoring whitelist patterns in project config {config_path} "
+                "(whitelist is only supported in user-level config ~/.config/schlock/config.yaml)"
+            )
+        return []
+
+    file_whitelist = data.get("whitelist", [])
+    if not isinstance(file_whitelist, list):
+        if file_whitelist:
+            logger.warning(f"Ignoring non-list whitelist value in {config_path}")
+        return []
+
+    patterns: list[str] = []
+    for pattern in file_whitelist:
+        if isinstance(pattern, str):
+            patterns.append(pattern)
+        else:
+            logger.warning(f"Skipping non-string whitelist pattern in {config_path}: {pattern!r}")
+    return patterns
+
+
+def _load_rule_overrides() -> tuple[dict, dict, list[str]]:
+    """Load rule/category overrides and whitelist patterns from config files.
 
     Reads config from both paths in precedence order (user first, project second).
     Project-level overrides win at the property level (not dict-level replace).
 
+    SECURITY: Whitelist patterns are loaded from user-level config ONLY.
+    Project-level config cannot define whitelist patterns because whitelist
+    bypasses ALL rules including BLOCKED — a malicious repo could exploit this.
+
     Returns:
-        Tuple of (rule_overrides, category_overrides). Empty dicts if none found.
-        Never raises exceptions.
+        Tuple of (rule_overrides, category_overrides, whitelist_patterns).
+        Empty dicts/list if none found. Never raises exceptions.
     """
     rule_overrides: dict = {}
     category_overrides: dict = {}
+    whitelist_patterns: list[str] = []
 
-    # Config paths in priority order (lowest first, highest last)
+    # Config paths: (path, is_user_level) in priority order (lowest first)
     # Path.home() can raise RuntimeError (HOME unset, e.g. containers/CI)
     # Path.cwd() can raise FileNotFoundError (cwd deleted)
-    config_paths: list[Path] = []
+    config_paths: list[tuple[Path, bool]] = []
     try:
-        config_paths.append(Path.home() / ".config" / "schlock" / "config.yaml")
+        config_paths.append((Path.home() / ".config" / "schlock" / "config.yaml", True))
     except Exception as e:
         logger.warning(f"Cannot resolve home directory for user config: {e}")
     try:
-        config_paths.append(Path.cwd() / ".claude" / "hooks" / "schlock-config.yaml")
+        config_paths.append((Path.cwd() / ".claude" / "hooks" / "schlock-config.yaml", False))
     except Exception as e:
         logger.warning(f"Cannot resolve working directory for project config: {e}")
 
-    for config_path in config_paths:
+    for config_path, is_user_level in config_paths:
         try:
             if not config_path.exists():
                 continue
@@ -193,11 +227,14 @@ def _load_rule_overrides() -> tuple[dict, dict]:
                     if isinstance(props, dict):
                         category_overrides.setdefault(cat_name, {}).update(props)
 
+            # Whitelist patterns (user-level only, see _extract_whitelist_patterns)
+            whitelist_patterns.extend(_extract_whitelist_patterns(data, config_path, is_user_level))
+
         except Exception as e:
             logger.warning(f"Failed to load overrides from {config_path}: {e}")
             continue
 
-    return rule_overrides, category_overrides
+    return rule_overrides, category_overrides, whitelist_patterns
 
 
 def load_rules(config_path: Optional[str] = None) -> RuleEngine:
@@ -239,9 +276,18 @@ def load_rules(config_path: Optional[str] = None) -> RuleEngine:
     engine = RuleEngine.from_directory(rules_dir)
 
     # Apply user/project overrides (only for default path, not test overrides)
-    rule_overrides, category_overrides = _load_rule_overrides()
+    rule_overrides, category_overrides, whitelist_patterns = _load_rule_overrides()
     if rule_overrides or category_overrides:
         engine.apply_overrides(rule_overrides, category_overrides)
+
+    # Apply user whitelist patterns (user-level config only, see _load_rule_overrides)
+    if whitelist_patterns:
+        try:
+            engine._compile_whitelist(whitelist_patterns)
+        except ConfigurationError as e:
+            # User config has invalid regex — log and continue without user patterns.
+            # Built-in whitelist patterns from 00_whitelist.yaml are unaffected.
+            logger.warning(f"Invalid whitelist pattern in user config, skipping: {e}")
 
     return engine
 

--- a/src/schlock/core/validator.py
+++ b/src/schlock/core/validator.py
@@ -281,12 +281,11 @@ def load_rules(config_path: Optional[str] = None) -> RuleEngine:
         engine.apply_overrides(rule_overrides, category_overrides)
 
     # Apply user whitelist patterns (user-level config only, see _load_rule_overrides)
-    if whitelist_patterns:
+    # Compile each pattern independently so one bad regex doesn't drop the rest.
+    for pattern in whitelist_patterns:
         try:
-            engine._compile_whitelist(whitelist_patterns)
+            engine._compile_whitelist([pattern])
         except ConfigurationError as e:
-            # User config has invalid regex — log and continue without user patterns.
-            # Built-in whitelist patterns from 00_whitelist.yaml are unaffected.
             logger.warning(f"Invalid whitelist pattern in user config, skipping: {e}")
 
     return engine

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -336,7 +336,7 @@ rule_overrides:
     enabled: false
 """)
         monkeypatch.chdir(tmp_path)
-        rule_overrides, category_overrides = _load_rule_overrides()
+        rule_overrides, category_overrides, _ = _load_rule_overrides()
         assert "recursive_delete" in rule_overrides
         assert rule_overrides["recursive_delete"]["enabled"] is False
         assert category_overrides == {}
@@ -351,7 +351,7 @@ category_overrides:
     risk_level: HIGH
 """)
         monkeypatch.chdir(tmp_path)
-        rule_overrides, category_overrides = _load_rule_overrides()
+        rule_overrides, category_overrides, _ = _load_rule_overrides()
         assert rule_overrides == {}
         assert "network_security" in category_overrides
         assert category_overrides["network_security"]["risk_level"] == "HIGH"
@@ -380,7 +380,7 @@ rule_overrides:
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "user_home")
         monkeypatch.chdir(tmp_path / "project")
 
-        rule_overrides, _ = _load_rule_overrides()
+        rule_overrides, _, _ = _load_rule_overrides()
         # enabled: false from user + risk_level: HIGH from project (overwrites user's LOW)
         assert rule_overrides["some_rule"]["enabled"] is False
         assert rule_overrides["some_rule"]["risk_level"] == "HIGH"
@@ -390,7 +390,7 @@ rule_overrides:
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
         monkeypatch.chdir(tmp_path)
 
-        rule_overrides, category_overrides = _load_rule_overrides()
+        rule_overrides, category_overrides, _ = _load_rule_overrides()
         assert rule_overrides == {}
         assert category_overrides == {}
 
@@ -402,10 +402,94 @@ rule_overrides:
 
         monkeypatch.chdir(tmp_path)
 
-        rule_overrides, category_overrides = _load_rule_overrides()
+        rule_overrides, category_overrides, _ = _load_rule_overrides()
         assert rule_overrides == {}
         assert category_overrides == {}
         assert "Failed to load overrides" in caplog.text
+
+    def test_load_whitelist_from_user_config(self, tmp_path, monkeypatch):
+        """Whitelist patterns loaded from user-level config."""
+        user_config = tmp_path / ".config" / "schlock"
+        user_config.mkdir(parents=True)
+        (user_config / "config.yaml").write_text("""
+whitelist:
+  - ^gcloud\\s+config\\s+get-value\\s+project
+  - ^my-safe-script\\.sh
+""")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        _, _, whitelist_patterns = _load_rule_overrides()
+        assert len(whitelist_patterns) == 2
+        assert whitelist_patterns[0] == r"^gcloud\s+config\s+get-value\s+project"
+        assert whitelist_patterns[1] == r"^my-safe-script\.sh"
+
+    def test_whitelist_patterns_bypass_blocked_rules(self, tmp_path, monkeypatch):
+        """User whitelist pattern allows a command that would otherwise be BLOCKED."""
+        clear_caches()
+        user_config = tmp_path / ".config" / "schlock"
+        user_config.mkdir(parents=True)
+        # Whitelist a specific gcloud command caught by gcp_credential_theft (BLOCKED)
+        (user_config / "config.yaml").write_text("""
+whitelist:
+  - ^gcloud\\s+config\\s+get-value\\s+project$
+""")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        result = validate_command("gcloud config get-value project")
+        assert result.allowed
+        assert result.risk_level == RiskLevel.SAFE
+
+    def test_whitelist_invalid_regex_skipped(self, tmp_path, monkeypatch, caplog):
+        """Invalid regex in whitelist logs warning, doesn't crash validation."""
+        clear_caches()
+        user_config = tmp_path / ".config" / "schlock"
+        user_config.mkdir(parents=True)
+        (user_config / "config.yaml").write_text("""
+whitelist:
+  - "[invalid(regex"
+""")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Should not crash — invalid pattern is skipped with warning
+        result = validate_command("echo hello")
+        assert result.allowed
+        assert "Invalid whitelist pattern" in caplog.text
+
+    def test_whitelist_ignored_from_project_config(self, tmp_path, monkeypatch, caplog):
+        """Project-level config whitelist patterns are NOT loaded (security)."""
+        project_config = tmp_path / ".claude" / "hooks"
+        project_config.mkdir(parents=True)
+        (project_config / "schlock-config.yaml").write_text("""
+whitelist:
+  - ^rm\\s+-rf\\s+/
+""")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent")
+        monkeypatch.chdir(tmp_path)
+
+        _, _, whitelist_patterns = _load_rule_overrides()
+        assert whitelist_patterns == []
+        assert "only supported in user-level config" in caplog.text
+
+    def test_self_protection_not_bypassable_via_whitelist(self, tmp_path, monkeypatch):
+        """Self-protection blocks config modification even with broad whitelist."""
+        clear_caches()
+        user_config = tmp_path / ".config" / "schlock"
+        user_config.mkdir(parents=True)
+        # Broad whitelist that matches everything
+        (user_config / "config.yaml").write_text("""
+whitelist:
+  - .*
+""")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Self-protection runs BEFORE whitelist matching — still blocked
+        result = validate_command("rm .claude/hooks/schlock-config.yaml")
+        assert not result.allowed
+        assert result.risk_level == RiskLevel.BLOCKED
 
 
 class TestSelfProtection:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -442,13 +442,16 @@ whitelist:
         assert result.risk_level == RiskLevel.SAFE
 
     def test_whitelist_invalid_regex_skipped(self, tmp_path, monkeypatch, caplog):
-        """Invalid regex in whitelist logs warning, doesn't crash validation."""
+        """Invalid regex in whitelist logs warning; valid patterns before and after still work."""
         clear_caches()
         user_config = tmp_path / ".config" / "schlock"
         user_config.mkdir(parents=True)
+        # Pattern sequence: valid, invalid, valid — all three must be independently handled
         (user_config / "config.yaml").write_text("""
 whitelist:
+  - ^gcloud\\s+config\\s+get-value\\s+project$
   - "[invalid(regex"
+  - ^my-safe-tool\\s+run$
 """)
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         monkeypatch.chdir(tmp_path)
@@ -457,6 +460,16 @@ whitelist:
         result = validate_command("echo hello")
         assert result.allowed
         assert "Invalid whitelist pattern" in caplog.text
+
+        # Valid pattern BEFORE the invalid one still works
+        result = validate_command("gcloud config get-value project")
+        assert result.allowed
+        assert result.risk_level == RiskLevel.SAFE
+
+        # Valid pattern AFTER the invalid one still works
+        result = validate_command("my-safe-tool run")
+        assert result.allowed
+        assert result.risk_level == RiskLevel.SAFE
 
     def test_whitelist_ignored_from_project_config(self, tmp_path, monkeypatch, caplog):
         """Project-level config whitelist patterns are NOT loaded (security)."""


### PR DESCRIPTION
## Summary

- Adds `whitelist:` key to user-level config (`~/.config/schlock/config.yaml`) — regex patterns that bypass ALL rules including BLOCKED
- Project-level config explicitly rejected for whitelist (privilege escalation risk — malicious repos could auto-whitelist dangerous commands)
- Self-protection runs BEFORE whitelist, so even a `.*` wildcard can't bypass config file protection
- Fixed `re.MULTILINE` bug in `_compile_whitelist()` — incorrect semantics with `match()`
- Changed whitelist matching from `search()` to `match()` (prefix-anchored, consistent with how patterns are documented)
- Invalid regex in user config logs a warning and skips gracefully (no crash)

## Security model

| Layer | Protection |
|-------|-----------|
| Self-protection | Runs first — whitelist cannot bypass config modification blocks |
| User-level only | Project config cannot define whitelist (prevents repo-level privilege escalation) |
| Prefix match | `re.match()` not `re.search()` — patterns anchor at command start |
| Graceful errors | Bad regex skipped with warning, doesn't break validation |

## Test plan

- [x] Whitelist patterns load from user config
- [x] Whitelisted command bypasses BLOCKED rules
- [x] Invalid regex skipped with warning
- [x] Project-level whitelist rejected with warning
- [x] Self-protection not bypassable via broad whitelist (`.*`)
- [x] Dangerous command variants after whitelisted patterns still blocked
- [x] Existing override tests updated for new 3-tuple return

Closes #66