### PR TITLE
feat(commit-filter): warn/block on commit messages not in argv (#76)

### DIFF
--- a/data/commit_filter_rules.yaml
+++ b/data/commit_filter_rules.yaml
@@ -4,6 +4,19 @@
 # Version
 version: "1.0.0"
 
+# Policy for commit messages whose content is NOT in the command string (issue #76):
+# delivery via -F/--file (a file or stdin) or an unevaluated $(...)/backtick substitution.
+# Such content cannot be scanned before the command runs, so schlock cannot strip a Claude
+# trailer from it. This setting decides what happens when such a commit is detected:
+#   off   - silent pass-through (legacy behavior; the gap is invisible)
+#   warn  - allow the commit but tell the model the message was not scanned (DEFAULT)
+#   block - deny the commit; the message must be inlined with -m to be scannable
+# This value is read from THIS bundled rules file. User/project override of commit_filter
+# settings is not yet wired (load_filter_config loads plugin defaults only), so edit it here.
+# NOTE: legitimate message reuse (git commit --amend --no-edit, -C/-c, --squash/--fixup,
+# --template, bare `git commit`) is NEVER flagged - there is no new content to smuggle.
+unscannable_message_action: warn
+
 # Rule Categories
 # Each category can be independently enabled/disabled
 rules:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -241,6 +241,47 @@ commit_filter:
 4. **Blocks commit** if patterns found (with clear error message)
 5. **User must remove** advertising and retry
 
+### Messages Not in the Command (file / stdin / substitution)
+
+The blocker scans the **command string**. Some git forms deliver the commit message from
+*outside* the command, so there is nothing in the command to scan (issue #76):
+
+- `git commit -F <file>` / `git commit --file=<file>` — message lives in a file
+- `git commit -F -` and heredocs — message arrives on stdin at execution time
+- `git commit -m "$(cat file)"` / backticks — the substitution is not expanded yet
+
+Because a `PreToolUse` hook runs **before** the command executes, this content does not exist
+where the hook can see it. The `unscannable_message_action` setting decides what happens when
+such a commit is detected:
+
+| Value | Behavior |
+|-------|----------|
+| `off` | Silent pass-through (legacy behavior — the gap is invisible) |
+| `warn` | **Default.** Allow the commit, but tell the model the message was not scanned |
+| `block` | Deny the commit; the message must be inlined with `-m` to be scannable |
+
+The default is `warn`. The value is read from the bundled rules file
+(`data/commit_filter_rules.yaml`):
+
+```yaml
+# data/commit_filter_rules.yaml
+unscannable_message_action: warn   # off | warn | block  (default: warn)
+```
+
+> **Heads up — not yet user-overridable.** `load_filter_config` currently loads only the
+> bundled plugin defaults; user/project override of `commit_filter` settings is not wired,
+> so change this in the rules file above. A reasonable intent if you later raise schlock's
+> risk tolerance: `off` for permissive, `warn` for balanced, `block` for paranoid.
+
+> **Legitimate reuse is never flagged.** `git commit --amend --no-edit`, `-C`/`-c`,
+> `--squash`/`--fixup`, `--template`, and a bare `git commit` (editor) supply no new
+> author-provided content, so they always pass through regardless of this setting.
+
+> **What `warn`/`block` can and cannot do.** This is a *pre-execution* heads-up: it cannot
+> read the file or stdin content, so it cannot confirm a trailer is present — only that the
+> message could not be scanned. The reliable place to catch a trailer that actually landed is
+> *after* the commit exists; detecting post-commit slippage is tracked separately.
+
 ### Why Block Instead of Filter?
 
 **Block-on-detection** (current approach):

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -460,8 +460,10 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
 
         # 2. FILTER FIRST (before safety validation)
         # Carries a non-blocking note attached to the final decision when an unscannable
-        # commit message (issue #76) is allowed under unscannable_message_action=warn.
+        # commit message (issue #76) is allowed under unscannable_message_action=warn, plus a
+        # dedicated audit violation so the warn is recorded on the final allow/ask audit entry.
         unscannable_warning = None
+        unscannable_audit_violation = None
         filter_instance = get_filter()
         if filter_instance:
             filter_result = filter_instance.filter_commit_message(command)
@@ -510,16 +512,17 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
                     }
                 }
 
-            # Issue #76: message is content-bearing but NOT in argv (file/stdin/unevaluated
-            # substitution), so it could not be scanned. Honor unscannable_message_action:
-            # block denies up front; warn rides a model-visible note on the final decision.
+            # Issue #76: message is content-bearing but NOT in argv (file/stdin), so it could
+            # not be scanned. Honor unscannable_message_action: block denies up front; warn
+            # rides a model-visible note on the final decision. Audit it under its OWN violation
+            # type — NOT "Advertising" (we never saw a trailer; the message was simply unscannable).
             if filter_result.unscannable_decision == "block":
                 logger.warning("[commit-filter] BLOCKED unscannable commit message (content not in argv)")
                 execution_time_ms = (time.perf_counter() - start_time) * 1000
                 audit_logger.log_validation(
                     command=command[:500],
                     risk_level="BLOCKED",
-                    violations=["Advertising: unscannable commit message"],
+                    violations=["commit_filter: unscannable commit message (block)"],
                     decision="block",
                     execution_time_ms=execution_time_ms,
                     context=context,
@@ -534,6 +537,8 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
             if filter_result.unscannable_decision == "warn":
                 logger.warning("[commit-filter] WARN unscannable commit message (content not in argv)")
                 unscannable_warning = filter_result.unscannable_reason
+                # Record the warn on the FINAL allow/ask audit entry (see violations assembly).
+                unscannable_audit_violation = "commit_filter: unscannable commit message (warn)"
 
         # 3. Ensure validator is initialized
         get_validator()
@@ -584,6 +589,11 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
         if shellcheck_findings:
             for finding in shellcheck_findings:
                 violations.append(f"ShellCheck {finding.sc_code}: {finding.message}")
+
+        # Record an unscannable-message warn on the final allow/ask audit entry (issue #76) so
+        # the detection is traceable, not just surfaced to the model via additionalContext.
+        if unscannable_audit_violation:
+            violations.append(unscannable_audit_violation)
 
         # 8. Build response and log audit event
         if decision == "allow":

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -459,6 +459,9 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
         logger.info(f"Validating command: {command[:100]}...")  # Log first 100 chars
 
         # 2. FILTER FIRST (before safety validation)
+        # Carries a non-blocking note attached to the final decision when an unscannable
+        # commit message (issue #76) is allowed under unscannable_message_action=warn.
+        unscannable_warning = None
         filter_instance = get_filter()
         if filter_instance:
             filter_result = filter_instance.filter_commit_message(command)
@@ -506,6 +509,31 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
                         "permissionDecisionReason": denial_message,
                     }
                 }
+
+            # Issue #76: message is content-bearing but NOT in argv (file/stdin/unevaluated
+            # substitution), so it could not be scanned. Honor unscannable_message_action:
+            # block denies up front; warn rides a model-visible note on the final decision.
+            if filter_result.unscannable_decision == "block":
+                logger.warning("[commit-filter] BLOCKED unscannable commit message (content not in argv)")
+                execution_time_ms = (time.perf_counter() - start_time) * 1000
+                audit_logger.log_validation(
+                    command=command[:500],
+                    risk_level="BLOCKED",
+                    violations=["Advertising: unscannable commit message"],
+                    decision="block",
+                    execution_time_ms=execution_time_ms,
+                    context=context,
+                )
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": f"BLOCKED: {filter_result.unscannable_reason}",
+                    }
+                }
+            if filter_result.unscannable_decision == "warn":
+                logger.warning("[commit-filter] WARN unscannable commit message (content not in argv)")
+                unscannable_warning = filter_result.unscannable_reason
 
         # 3. Ensure validator is initialized
         get_validator()
@@ -568,7 +596,10 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
                 execution_time_ms=execution_time_ms,
                 context=context,
             )
-            return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+            allow_output = {"hookEventName": "PreToolUse", "permissionDecision": "allow"}
+            if unscannable_warning:
+                allow_output["additionalContext"] = unscannable_warning
+            return {"hookSpecificOutput": allow_output}
 
         if decision == "ask":
             # Prompt user for approval (HIGH risk or ShellCheck findings)
@@ -585,13 +616,14 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
                 execution_time_ms=execution_time_ms,
                 context=context,
             )
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "ask",
-                    "permissionDecisionReason": message,
-                }
+            ask_output = {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "ask",
+                "permissionDecisionReason": message,
             }
+            if unscannable_warning:
+                ask_output["additionalContext"] = unscannable_warning
+            return {"hookSpecificOutput": ask_output}
 
         # Blocked case (decision == "deny")
         message = format_message(result, decision="deny")

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -395,6 +395,10 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
     start_time = time.perf_counter()
     audit_logger = get_audit_logger()
     context = get_context()
+    # Issue #76: an unscannable-message (file/stdin) detection must reach whichever audit entry
+    # ultimately fires. Initialized before the try so the except handlers can read them safely.
+    unscannable_warning = None
+    unscannable_audit_violation = None
 
     try:
         # 1. Extract command from stdin JSON
@@ -459,11 +463,6 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
         logger.info(f"Validating command: {command[:100]}...")  # Log first 100 chars
 
         # 2. FILTER FIRST (before safety validation)
-        # Carries a non-blocking note attached to the final decision when an unscannable
-        # commit message (issue #76) is allowed under unscannable_message_action=warn, plus a
-        # dedicated audit violation so the warn is recorded on the final allow/ask audit entry.
-        unscannable_warning = None
-        unscannable_audit_violation = None
         filter_instance = get_filter()
         if filter_instance:
             filter_result = filter_instance.filter_commit_message(command)
@@ -550,10 +549,13 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
         if result.error:
             logger.error(f"Validation error: {result.error}")
             execution_time_ms = (time.perf_counter() - start_time) * 1000
+            error_violations = [f"Validation error: {result.error}"]
+            if unscannable_audit_violation:
+                error_violations.append(unscannable_audit_violation)
             audit_logger.log_validation(
                 command=command[:500],
                 risk_level="BLOCKED",
-                violations=[f"Validation error: {result.error}"],
+                violations=error_violations,
                 decision="block",
                 execution_time_ms=execution_time_ms,
                 context=context,
@@ -658,10 +660,13 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
         # Validator initialization failed
         logger.error(f"RuntimeError in hook: {e}")
         execution_time_ms = (time.perf_counter() - start_time) * 1000
+        rt_violations = [f"RuntimeError: {str(e)}"]
+        if unscannable_audit_violation:
+            rt_violations.append(unscannable_audit_violation)
         audit_logger.log_validation(
             command=input_data.get("tool_input", {}).get("command", "<unknown>")[:500],
             risk_level="BLOCKED",
-            violations=[f"RuntimeError: {str(e)}"],
+            violations=rt_violations,
             decision="block",
             execution_time_ms=execution_time_ms,
             context=context,
@@ -678,10 +683,13 @@ def handle_pre_tool_use(input_data: dict) -> dict:  # noqa: PLR0915, PLR0911, PL
         # Catch-all for unexpected errors
         logger.error(f"Unexpected error in hook: {e}", exc_info=True)
         execution_time_ms = (time.perf_counter() - start_time) * 1000
+        unexpected_violations = [f"Unexpected error: {str(e)}"]
+        if unscannable_audit_violation:
+            unexpected_violations.append(unscannable_audit_violation)
         audit_logger.log_validation(
             command=input_data.get("tool_input", {}).get("command", "<unknown>")[:500],
             risk_level="BLOCKED",
-            violations=[f"Unexpected error: {str(e)}"],
+            violations=unexpected_violations,
             decision="block",
             execution_time_ms=execution_time_ms,
             context=context,

--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -284,18 +284,24 @@ class CommitMessageFilter:
         extracting twice. ``extracted`` is ``extract_commit_message``'s result for a command
         already known to be a git commit.
 
-        A message that extracted is literally present in argv -> ``scannable`` (scan it,
-        incidental substitutions and all). Otherwise a file/stdin flag means the content exists
-        but not in argv -> ``unscannable``; anything else is reuse/editor deferral -> ``none``.
+        A file/stdin flag in ANY git commit segment means part of the command is content not
+        in argv -> ``unscannable`` (checked FIRST: a compound `git commit -m x && git commit -F
+        y` must not be masked as scannable by the earlier inline message). Otherwise an extracted
+        message is literally in argv -> ``scannable`` (scan it, incidental substitutions and all);
+        anything else is reuse/editor deferral -> ``none``.
         """
+        if self._command_has_file_content_flag(command):
+            return "unscannable"
         if extracted is not None:
             return "scannable"
-        return "unscannable" if self._command_has_file_content_flag(command) else "none"
+        return "none"
 
     def _command_has_file_content_flag(self, command: str) -> bool:
         """True if any git commit segment delivers its message from a file or stdin (-F/--file)."""
         for words in self._git_commit_word_lists(command):
-            for word in words:
+            for word in words[2:]:  # skip "git commit"; flags follow the subcommand
+                if word == "--":
+                    break  # everything after the option terminator is a pathspec, not a flag
                 if word == "--file" or word.startswith("--file="):
                     return True
                 # Single-dash short-flag cluster: -F, attached -Fpath, or clustered -aF / -aFpath.
@@ -621,11 +627,13 @@ class CommitMessageFilter:
             message = self.extract_commit_message(command)
             delivery = self._classify_from_extraction(command, message)
 
-            # Content-bearing but NOT in argv (file / stdin / unevaluated substitution) -> #76.
-            # We cannot scan it pre-execution; surface a warn/block decision per config.
+            # Content-bearing but NOT in argv (file / stdin) -> #76. We cannot scan it
+            # pre-execution; surface a warn/block decision per config.
             if delivery == "unscannable":
                 if self.unscannable_action == "off":
-                    # Opt-out: preserve historical silent fail-open behavior.
+                    # Opt-out: preserve historical silent pass-through. This is a deliberate
+                    # skip, NOT a failure, so `error` stays None (the state is recorded by
+                    # message_delivery="unscannable" + unscannable_decision=None).
                     return FilterResult(
                         cleaned_command=command,
                         original_message="",
@@ -633,7 +641,6 @@ class CommitMessageFilter:
                         was_modified=False,
                         message_delivery="unscannable",
                         unscannable_decision=None,
-                        error="Commit message supplied outside argv; not scanned (action=off)",
                     )
                 logger.warning("[commit-filter] Unscannable commit message (file/stdin); action=%s", self.unscannable_action)
                 return FilterResult(

--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -55,6 +55,13 @@ class FilterResult:
         patterns_removed: List of patterns that matched (with category info)
         categories_matched: List of category names that had matches
         error: Error message if filtering failed (None on success)
+        message_delivery: How the message reaches git ("scannable" | "unscannable" | "none").
+            See CommitMessageFilter.classify_message_delivery.
+        unscannable_decision: Decision for an unscannable content-bearing commit (issue #76):
+            None (not applicable, or policy is "off"), "warn", or "block". Distinct from the
+            filter's configured policy CommitMessageFilter.unscannable_action ("off" maps here
+            to None); this field is the per-command outcome the hook acts on.
+        unscannable_reason: Human-readable explanation when unscannable_decision is set.
     """
 
     cleaned_command: str
@@ -64,6 +71,9 @@ class FilterResult:
     patterns_removed: list[dict[str, str]] = field(default_factory=list)
     categories_matched: list[str] = field(default_factory=list)
     error: Optional[str] = None
+    message_delivery: str = "none"
+    unscannable_decision: Optional[str] = None
+    unscannable_reason: str = ""
 
 
 class CommitMessageFilter:
@@ -106,6 +116,12 @@ class CommitMessageFilter:
         """
         self.config = config
         self.enabled = config.get("enabled", True)  # Default: enabled
+
+        # Policy for commit messages whose content is NOT in argv (issue #76): file/stdin
+        # delivery or unevaluated substitution. "warn" is the safe default — non-destructive
+        # but not silent. Invalid values fall back to "warn" rather than raising.
+        action = str(config.get("unscannable_message_action", "warn")).strip().lower()
+        self.unscannable_action = action if action in ("off", "warn", "block") else "warn"
 
         # Compile patterns from enabled categories
         self._compiled_patterns: list[tuple[re.Pattern, str, str, str]] = []
@@ -229,6 +245,120 @@ class CommitMessageFilter:
 
         # Both methods failed → fail-open (return None)
         return None
+
+    def classify_message_delivery(self, command: str) -> str:
+        """Classify how a git commit command delivers its message.
+
+        Returns one of:
+            "scannable"   - a message was extracted from argv (any ``-m "..."`` form). Its
+                            literal bytes are in the command, so it is scanned as-is - an
+                            incidental ``$(...)`` does not stop the literal parts (including a
+                            trailer) from being matched and stripped.
+            "unscannable" - the message is delivered from OUTSIDE argv: ``-F`` / ``--file``
+                            (a file, or ``-`` for stdin). There is nothing in the command to
+                            scan, so the filter can only warn or block - it cannot strip.
+            "none"        - no NEW author-supplied message content (bare ``git commit``,
+                            ``--amend --no-edit``, ``-C`` / ``-c`` / ``--squash`` /
+                            ``--fixup`` / ``--template`` message reuse or editor deferral).
+
+        WHY THIS EXISTS: ``extract_commit_message`` returns ``None`` for BOTH legitimate
+        message reuse (``--amend --no-edit``, ``-C HEAD``) and the issue #76 file bypass
+        (``-F file``). Acting on the bare ``None`` signal would block every amend/reuse, so
+        this method separates "content we structurally cannot see" from "no new content".
+
+        NOTE: ``-m "$(cat externalfile)"`` (the WHOLE message is a substitution) is treated as
+        ``scannable`` - its literal ``$(...)`` text is scanned and matches nothing, so it slips
+        pre-execution. Catching that reliably needs the ACTUAL committed message (a post-commit
+        check), not argv inspection - argv genuinely does not contain the bytes. Pure and
+        side-effect free. Public entry point used by tests; ``filter_commit_message`` shares the
+        core decision via ``_classify_from_extraction``.
+        """
+        if not self.is_git_commit_command(command):
+            return "none"
+        return self._classify_from_extraction(command, self.extract_commit_message(command))
+
+    def _classify_from_extraction(self, command: str, extracted: Optional[str]) -> str:
+        """Classify delivery given an already-extracted message (shared with filtering).
+
+        Split out so ``filter_commit_message`` can extract once and classify rather than
+        extracting twice. ``extracted`` is ``extract_commit_message``'s result for a command
+        already known to be a git commit.
+
+        A message that extracted is literally present in argv -> ``scannable`` (scan it,
+        incidental substitutions and all). Otherwise a file/stdin flag means the content exists
+        but not in argv -> ``unscannable``; anything else is reuse/editor deferral -> ``none``.
+        """
+        if extracted is not None:
+            return "scannable"
+        return "unscannable" if self._command_has_file_content_flag(command) else "none"
+
+    def _command_has_file_content_flag(self, command: str) -> bool:
+        """True if any git commit segment delivers its message from a file or stdin (-F/--file)."""
+        for words in self._git_commit_word_lists(command):
+            for word in words:
+                if word == "--file" or word.startswith("--file="):
+                    return True
+                # Single-dash short-flag cluster: -F, attached -Fpath, or clustered -aF / -aFpath.
+                if word.startswith("-") and not word.startswith("--") and self._short_cluster_has_file_flag(word):
+                    return True
+        return False
+
+    @staticmethod
+    def _short_cluster_has_file_flag(token: str) -> bool:
+        """True if a single-dash short-flag cluster uses -F (commit message from a file/stdin).
+
+        Walks the cluster letters: -m/-C/-c also take arguments, so reaching one of THOSE first
+        means the remainder is that flag's value (e.g. -mFix is message "Fix", not a file flag).
+        Reaching 'F' first means file delivery (handles -F, -Fpath, -aF, -aFpath).
+        """
+        for ch in token[1:]:
+            if ch == "F":
+                return True
+            if ch in "mCc":  # argument-taking flag; the rest of the token is its value, not flags
+                return False
+        return False
+
+    # Explanation surfaced when an unscannable commit is warned/blocked. Unscannable always
+    # means file/stdin delivery (-F/--file), so a single static message suffices.
+    _UNSCANNABLE_REASON = (
+        "Commit message supplied via a file or stdin (-F/--file); its content is not in the "
+        "command and was not scanned for advertising. Inline the message with -m to enable "
+        "scanning, or remove any unwanted trailer manually."
+    )
+
+    def _git_commit_word_lists(self, command: str) -> list[list[str]]:
+        """Return the argv word lists of every ``git commit`` invocation in the command.
+
+        Uses bashlex to isolate the git commit segment(s) of a compound command. On parse
+        failure (or an oversized command) falls back to splitting the whole command -
+        over-detecting a file flag and warning is safer than silently missing it for this
+        fail-open filter, and never parsing an oversized string avoids a DoS on the hook.
+        """
+        if len(command) > MAX_COMMAND_SIZE:  # DoS guard: never run bashlex on an oversized command
+            return [command.split()]
+        try:
+            parts = bashlex.parse(command)
+        except Exception:  # noqa: BLE001 - bashlex raises various types; fail-open to split
+            return [command.split()]
+
+        results: list[list[str]] = []
+
+        def visit(node: Any) -> None:
+            if getattr(node, "kind", None) == "command":
+                words = [p.word for p in getattr(node, "parts", []) if hasattr(p, "word")]
+                if len(words) >= 2 and words[0] == "git" and words[1] == "commit":
+                    results.append(words)
+            for attr in ("parts", "list", "command"):
+                child = getattr(node, attr, None)
+                if child is None:
+                    continue
+                for item in child if isinstance(child, list) else [child]:
+                    visit(item)
+
+        for part in parts:
+            visit(part)
+
+        return results if results else [command.split()]
 
     def _extract_via_bashlex(self, command: str) -> Optional[str]:
         """Extract commit message using bashlex AST parsing.
@@ -487,20 +617,47 @@ class CommitMessageFilter:
                     categories_matched=[],
                 )
 
-            # Extract message
+            # Extract once and classify how the message is delivered to git.
             message = self.extract_commit_message(command)
-            if message is None:
-                # Could not extract message -> fail-open (allow original)
-                logger.warning("Could not extract commit message from command")
+            delivery = self._classify_from_extraction(command, message)
+
+            # Content-bearing but NOT in argv (file / stdin / unevaluated substitution) -> #76.
+            # We cannot scan it pre-execution; surface a warn/block decision per config.
+            if delivery == "unscannable":
+                if self.unscannable_action == "off":
+                    # Opt-out: preserve historical silent fail-open behavior.
+                    return FilterResult(
+                        cleaned_command=command,
+                        original_message="",
+                        cleaned_message="",
+                        was_modified=False,
+                        message_delivery="unscannable",
+                        unscannable_decision=None,
+                        error="Commit message supplied outside argv; not scanned (action=off)",
+                    )
+                logger.warning("[commit-filter] Unscannable commit message (file/stdin); action=%s", self.unscannable_action)
                 return FilterResult(
                     cleaned_command=command,
                     original_message="",
                     cleaned_message="",
                     was_modified=False,
-                    patterns_removed=[],
-                    categories_matched=[],
-                    error="Could not extract commit message",
+                    message_delivery="unscannable",
+                    unscannable_decision=self.unscannable_action,
+                    unscannable_reason=self._UNSCANNABLE_REASON,
                 )
+
+            # No NEW author-supplied content (bare commit, --amend --no-edit, -C/-c/--squash/
+            # --fixup/--template). Legitimate reuse/deferral -> pass through, never flag.
+            if delivery == "none":
+                return FilterResult(
+                    cleaned_command=command,
+                    original_message="",
+                    cleaned_message="",
+                    was_modified=False,
+                    message_delivery="none",
+                )
+
+            # delivery == "scannable": by the classifier contract `message` is non-None here.
 
             # Clean message
             cleaned, patterns_removed, categories = self.clean_message(message)
@@ -517,6 +674,7 @@ class CommitMessageFilter:
                     was_modified=False,
                     patterns_removed=[],
                     categories_matched=[],
+                    message_delivery="scannable",
                 )
 
             # Check if cleaned message is empty
@@ -529,6 +687,7 @@ class CommitMessageFilter:
                     was_modified=False,  # Don't use cleaned (it's empty)
                     patterns_removed=patterns_removed,
                     categories_matched=categories,
+                    message_delivery="scannable",
                     error="Commit message is empty after filtering",
                 )
 
@@ -542,6 +701,7 @@ class CommitMessageFilter:
                 was_modified=True,
                 patterns_removed=patterns_removed,
                 categories_matched=categories,
+                message_delivery="scannable",
             )
 
         except Exception as e:

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -405,16 +405,23 @@ class TestFilterOrchestration:
         assert not result.was_modified
         assert result.cleaned_command == cmd
 
-    def test_fails_open_on_extraction_failure(self):
-        """Returns original command when extraction fails."""
+    def test_amend_message_reuse_passes_through_cleanly(self):
+        """git commit --amend reuses the existing message (no NEW content) -> clean pass.
+
+        Previously this was treated as an extraction *failure* (error set). It is not a
+        failure: there is simply no new author-supplied content to scan, so it must pass
+        through cleanly without flagging, exactly like every routine amend/reuse.
+        """
         filter_instance = CommitMessageFilter({"enabled": True, "rules": {}})
 
-        cmd = "git commit --amend"  # No -m flag
+        cmd = "git commit --amend"  # No -m flag: reuses existing message via editor
         result = filter_instance.filter_commit_message(cmd)
 
         assert not result.was_modified
-        assert result.cleaned_command == cmd
-        assert result.error is not None
+        assert result.cleaned_command == cmd  # commit not broken
+        assert result.message_delivery == "none"
+        assert result.unscannable_decision is None
+        assert result.error is None  # legitimate reuse, not a failure
 
     def test_fails_open_on_empty_message_after_filtering(self):
         """Returns original when cleaned message is empty."""
@@ -537,17 +544,23 @@ class TestErrorHandling:
         filter_instance = CommitMessageFilter(config)
         assert len(filter_instance._compiled_patterns) == 0  # Pattern skipped
 
-    def test_handles_extraction_failure_gracefully(self):
-        """Handles extraction failure without breaking."""
-        filter_instance = CommitMessageFilter({"enabled": True, "rules": {}})
+    def test_off_action_records_error_without_breaking_commit(self):
+        """With unscannable_message_action=off, an unscannable (file-delivered) message
+        passes through with an explanatory, non-fatal error and the command intact.
 
-        # Command with no extractable message
-        cmd = "git commit --amend"
+        This is the genuine graceful-degradation path: schlock cannot scan content that
+        is not in argv, so when the user opts out of warn/block it records WHY and never
+        modifies or breaks the commit.
+        """
+        filter_instance = CommitMessageFilter({"enabled": True, "rules": {}, "unscannable_message_action": "off"})
+
+        cmd = "git commit -F /tmp/msg.txt"  # content on disk, not scannable
         result = filter_instance.filter_commit_message(cmd)
 
         assert not result.was_modified
-        assert result.cleaned_command == cmd  # Original
-        assert result.error is not None  # Error logged
+        assert result.cleaned_command == cmd  # Original, commit not broken
+        assert result.error is not None  # Explanatory, non-fatal
+        assert result.unscannable_decision is None  # off -> no warn/block surfaced
 
     def test_catches_unexpected_exceptions(self):
         """Catches unexpected exceptions and fails open."""
@@ -707,3 +720,261 @@ class TestPerformance:
 
         # Same object reference means no recompilation
         assert patterns_before is patterns_after
+
+
+class TestMessageDeliveryClassification:
+    """classify_message_delivery distinguishes three commit-message delivery classes.
+
+    This is the content-aware detector that makes ``warn`` a safe default. The bare
+    ``None`` extraction signal is overloaded: ``git commit --amend --no-edit``,
+    ``git commit -C HEAD`` (legit message reuse) and ``git commit -F file`` (the #76
+    advertising bypass) ALL extract to ``None``. Policy keyed on extraction alone would
+    block every amend/reuse. The classifier separates them:
+
+    - ``scannable``   a message extracted from argv (any ``-m "..."`` form). Its literal bytes
+                      are present, so it is scanned as-is even if it embeds an incidental
+                      ``$(...)`` - the literal parts (including a trailer) are still matched.
+    - ``unscannable`` the message is delivered from OUTSIDE argv: ``-F``/``--file`` (a file, or
+                      ``-`` for stdin). Nothing in the command to scan -> warn/block only.
+    - ``none``        no NEW author-supplied content (bare commit, ``--amend --no-edit``,
+                      ``-C``/``-c``/``--squash``/``--fixup``/``--template`` -> nothing to smuggle)
+    """
+
+    @staticmethod
+    def _filter():
+        return CommitMessageFilter({"enabled": True, "rules": {}})
+
+    # --- scannable: content is inline in argv ---
+
+    def test_inline_message_is_scannable(self):
+        """Plain inline -m message is scannable."""
+        assert self._filter().classify_message_delivery('git commit -m "fix: a bug"') == "scannable"
+
+    def test_inline_heredoc_substitution_is_scannable(self):
+        """-m "$(cat <<'EOF'...EOF)" inline heredoc body is literally in argv -> scannable."""
+        cmd = "git commit -m \"$(cat <<'EOF'\nfix: a bug\nEOF\n)\""
+        assert self._filter().classify_message_delivery(cmd) == "scannable"
+
+    # --- unscannable: content-bearing flag points outside argv ---
+
+    def test_file_flag_short_is_unscannable(self):
+        """git commit -F file -> content on disk, not argv."""
+        assert self._filter().classify_message_delivery("git commit -F /tmp/msg.txt") == "unscannable"
+
+    def test_file_flag_attached_long_is_unscannable(self):
+        """git commit --file=file -> unscannable."""
+        assert self._filter().classify_message_delivery("git commit --file=/tmp/msg.txt") == "unscannable"
+
+    def test_file_flag_separated_long_is_unscannable(self):
+        """git commit --file file -> unscannable."""
+        assert self._filter().classify_message_delivery("git commit --file /tmp/msg.txt") == "unscannable"
+
+    def test_file_flag_attached_short_is_unscannable(self):
+        """git commit -F/tmp/msg.txt (attached) -> unscannable."""
+        assert self._filter().classify_message_delivery("git commit -F/tmp/msg.txt") == "unscannable"
+
+    def test_amend_with_file_is_unscannable(self):
+        """--amend alone would be 'none', but -F supplies content -> unscannable wins."""
+        assert self._filter().classify_message_delivery("git commit --amend -F /tmp/msg.txt") == "unscannable"
+
+    def test_stdin_dash_file_is_unscannable(self):
+        """git commit -F - reads the message from stdin -> unscannable."""
+        assert self._filter().classify_message_delivery("git commit -F -") == "unscannable"
+
+    def test_external_command_substitution_is_scannable(self):
+        """-m "$(cat externalfile)": the literal $(...) text IS in argv -> scannable.
+
+        We scan the literal token (which matches nothing for a pure substitution), so it
+        slips pre-execution; that niche bypass is deferred to the post-commit check. We do
+        NOT treat it as unscannable, because doing so would also stop scanning -m messages
+        that merely embed an incidental substitution alongside a literal trailer.
+        """
+        assert self._filter().classify_message_delivery('git commit -m "$(cat /tmp/msg.txt)"') == "scannable"
+
+    def test_backtick_substitution_is_scannable(self):
+        """-m "`cat externalfile`": the literal backtick text is in argv -> scannable (see above)."""
+        assert self._filter().classify_message_delivery('git commit -m "`cat /tmp/msg.txt`"') == "scannable"
+
+    # --- none: no NEW author-supplied content (legit reuse / defer) ---
+
+    def test_bare_commit_is_none(self):
+        """Bare git commit opens an editor; no new argv content."""
+        assert self._filter().classify_message_delivery("git commit") == "none"
+
+    def test_amend_no_edit_is_none(self):
+        """--amend --no-edit reuses the existing message; nothing to smuggle."""
+        assert self._filter().classify_message_delivery("git commit --amend --no-edit") == "none"
+
+    def test_reuse_message_short_is_none(self):
+        """-C HEAD reuses another commit's message."""
+        assert self._filter().classify_message_delivery("git commit -C HEAD") == "none"
+
+    def test_reuse_message_long_is_none(self):
+        """--reuse-message=HEAD reuses another commit's message."""
+        assert self._filter().classify_message_delivery("git commit --reuse-message=HEAD") == "none"
+
+    def test_reedit_message_is_none(self):
+        """-c HEAD~1 reedits a reused message (editor-based)."""
+        assert self._filter().classify_message_delivery("git commit -c HEAD~1") == "none"
+
+    def test_squash_is_none(self):
+        """--squash=HEAD defers message to rebase."""
+        assert self._filter().classify_message_delivery("git commit --squash=HEAD") == "none"
+
+    def test_fixup_is_none(self):
+        """--fixup=HEAD defers message to rebase."""
+        assert self._filter().classify_message_delivery("git commit --fixup=HEAD") == "none"
+
+    def test_template_is_none(self):
+        """--template populates the editor; no non-interactive content."""
+        assert self._filter().classify_message_delivery("git commit --template=/tmp/tpl.txt") == "none"
+
+    def test_non_git_commit_is_none(self):
+        """Non git-commit commands have no message to classify."""
+        assert self._filter().classify_message_delivery("ls -la") == "none"
+
+    def test_compound_command_with_file_is_unscannable(self):
+        """Locates the git commit segment in a compound command."""
+        cmd = "git add -A && git commit -F /tmp/msg.txt"
+        assert self._filter().classify_message_delivery(cmd) == "unscannable"
+
+    # --- a -m message that embeds substitution chars is still scannable (no false "unscannable") ---
+    # (panel finding A: an earlier quote-aware classifier mis-flagged single-quoted literals; the
+    #  fix is simpler - any extracted -m value is literally in argv, so it is always scannable.)
+
+    def test_single_quoted_dollar_paren_is_scannable(self):
+        """git commit -m 'fix $(x) parsing' is a literal in argv -> scannable."""
+        assert self._filter().classify_message_delivery("git commit -m 'fix $(x) parsing'") == "scannable"
+
+    def test_single_quoted_backtick_is_scannable(self):
+        """git commit -m 'use `make` to build' is a literal in argv -> scannable."""
+        assert self._filter().classify_message_delivery("git commit -m 'use `make` to build'") == "scannable"
+
+    # --- combined short-flag cluster (panel finding B): -aF still delivers via file ---
+
+    def test_combined_short_flag_cluster_is_unscannable(self):
+        """git commit -aF /tmp/msg.txt clusters -a and -F; the -F file delivery must be seen."""
+        assert self._filter().classify_message_delivery("git commit -aF /tmp/msg.txt") == "unscannable"
+
+    # --- DoS guard (panel finding C): oversized command must not parse the whole string ---
+
+    def test_oversized_command_skips_bashlex_parse(self):
+        """An oversized command must never reach bashlex.parse (DoS guard), yet still classify."""
+        cmd = "git commit -F /tmp/msg.txt " + ("a " * 40000)  # > MAX_COMMAND_SIZE, many tokens
+        with patch("schlock.integrations.commit_filter.bashlex.parse") as mock_parse:
+            result = self._filter().classify_message_delivery(cmd)
+        mock_parse.assert_not_called()  # guard short-circuits before parsing the whole string
+        assert result == "unscannable"  # split fallback still sees -F
+
+
+class TestUnscannableMessageAction:
+    """filter_commit_message surfaces a warn/block decision for unscannable
+    content-bearing commits (issue #76), governed by ``unscannable_message_action``
+    (off | warn | block; default warn). ``none`` delivery (reuse/amend) is never flagged,
+    and scannable advertising is still cleaned exactly as before.
+    """
+
+    @staticmethod
+    def _filter(action=None, rules=None):
+        cfg = {"enabled": True, "rules": rules or {}}
+        if action is not None:
+            cfg["unscannable_message_action"] = action
+        return CommitMessageFilter(cfg)
+
+    def test_default_action_is_warn(self):
+        """Unspecified action defaults to warn (non-destructive, but not silent)."""
+        assert self._filter().unscannable_action == "warn"
+
+    def test_invalid_action_falls_back_to_warn(self):
+        """An invalid action value falls back to the safe default rather than raising."""
+        assert self._filter(action="bogus").unscannable_action == "warn"
+
+    def test_off_action_respected(self):
+        """unscannable_message_action: off is preserved on the instance."""
+        assert self._filter(action="off").unscannable_action == "off"
+
+    def test_file_form_warns_by_default(self):
+        """git commit -F file is flagged warn by default, command left unmodified."""
+        result = self._filter().filter_commit_message("git commit -F /tmp/msg.txt")
+        assert result.message_delivery == "unscannable"
+        assert result.unscannable_decision == "warn"
+        assert not result.was_modified
+        assert result.unscannable_reason  # non-empty human explanation
+        assert result.cleaned_command == "git commit -F /tmp/msg.txt"
+
+    def test_file_form_blocks_when_configured(self):
+        """unscannable_message_action: block surfaces a block decision."""
+        result = self._filter(action="block").filter_commit_message("git commit -F /tmp/msg.txt")
+        assert result.message_delivery == "unscannable"
+        assert result.unscannable_decision == "block"
+
+    def test_file_form_silent_when_off(self):
+        """unscannable_message_action: off restores today's silent fail-open (no decision)."""
+        result = self._filter(action="off").filter_commit_message("git commit -F /tmp/msg.txt")
+        assert result.message_delivery == "unscannable"
+        assert result.unscannable_decision is None
+        assert not result.was_modified
+
+    def test_stdin_form_warns(self):
+        """git commit -F - (message on stdin) is flagged unscannable -> warn."""
+        result = self._filter().filter_commit_message("git commit -F -")
+        assert result.message_delivery == "unscannable"
+        assert result.unscannable_decision == "warn"
+
+    def test_inline_substitution_is_scannable_not_flagged(self):
+        """-m "$(cat externalfile)": literal $(...) is in argv -> scannable, never warn/block."""
+        result = self._filter().filter_commit_message('git commit -m "$(cat /tmp/msg.txt)"')
+        assert result.message_delivery == "scannable"
+        assert result.unscannable_decision is None
+
+    def test_amend_no_edit_not_flagged(self):
+        """--amend --no-edit reuses a message; never flagged regardless of action."""
+        result = self._filter(action="block").filter_commit_message("git commit --amend --no-edit")
+        assert result.message_delivery == "none"
+        assert result.unscannable_decision is None
+        assert not result.was_modified
+
+    def test_reuse_message_not_flagged(self):
+        """-C HEAD reuses a message; never flagged."""
+        result = self._filter(action="block").filter_commit_message("git commit -C HEAD")
+        assert result.message_delivery == "none"
+        assert result.unscannable_decision is None
+
+    def test_scannable_advertising_still_cleaned(self):
+        """Regression: scannable inline advertising is still detected and cleaned."""
+        rules = {
+            "advertising": {
+                "enabled": True,
+                "patterns": [{"pattern": "Generated with Claude Code", "description": "ad", "replacement": ""}],
+            }
+        }
+        cmd = 'git commit -m "feat: x\\n\\nGenerated with Claude Code"'
+        result = self._filter(rules=rules).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+        assert result.unscannable_decision is None
+
+    def test_scannable_clean_message_unmodified(self):
+        """A clean scannable message is neither modified nor flagged."""
+        result = self._filter().filter_commit_message('git commit -m "feat: clean"')
+        assert result.message_delivery == "scannable"
+        assert result.unscannable_decision is None
+        assert not result.was_modified
+
+    def test_inline_substitution_with_literal_trailer_is_still_cleaned(self):
+        """Regression guard: a -m message with an INCIDENTAL substitution but a LITERAL trailer
+        must still be scanned and the trailer stripped. The literal bytes are in argv; an
+        incidental $(...) elsewhere must not disable scanning of the rest."""
+        rules = {
+            "advertising": {
+                "enabled": True,
+                "patterns": [
+                    {"pattern": "\\n*Co-Authored-By:.*Claude.*\\n*", "description": "claude trailer", "replacement": "\n"}
+                ],
+            }
+        }
+        cmd = 'git commit -m "Deploy $(date)\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+        result = self._filter(rules=rules).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed  # the literal trailer IS caught despite the $(date)
+        assert result.unscannable_decision is None

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -544,13 +544,12 @@ class TestErrorHandling:
         filter_instance = CommitMessageFilter(config)
         assert len(filter_instance._compiled_patterns) == 0  # Pattern skipped
 
-    def test_off_action_records_error_without_breaking_commit(self):
+    def test_off_action_passes_through_without_error(self):
         """With unscannable_message_action=off, an unscannable (file-delivered) message
-        passes through with an explanatory, non-fatal error and the command intact.
-
-        This is the genuine graceful-degradation path: schlock cannot scan content that
-        is not in argv, so when the user opts out of warn/block it records WHY and never
-        modifies or breaks the commit.
+        passes through cleanly. ``error`` is reserved for genuine filter FAILURES, so a
+        deliberate config-driven pass-through must NOT set it (else downstream callers and
+        audit data can't tell a chosen skip from a real failure). The skip is recorded by
+        message_delivery="unscannable" + unscannable_decision=None instead.
         """
         filter_instance = CommitMessageFilter({"enabled": True, "rules": {}, "unscannable_message_action": "off"})
 
@@ -559,7 +558,8 @@ class TestErrorHandling:
 
         assert not result.was_modified
         assert result.cleaned_command == cmd  # Original, commit not broken
-        assert result.error is not None  # Explanatory, non-fatal
+        assert result.error is None  # deliberate skip is NOT a failure
+        assert result.message_delivery == "unscannable"
         assert result.unscannable_decision is None  # off -> no warn/block surfaced
 
     def test_catches_unexpected_exceptions(self):
@@ -865,6 +865,23 @@ class TestMessageDeliveryClassification:
             result = self._filter().classify_message_delivery(cmd)
         mock_parse.assert_not_called()  # guard short-circuits before parsing the whole string
         assert result == "unscannable"  # split fallback still sees -F
+
+    # --- compound-command bypass (CodeRabbit): a -F in ANY segment wins over an earlier -m ---
+
+    def test_compound_inline_then_file_is_unscannable(self):
+        """git commit -m "ok" && git commit -F file: the 2nd commit's -F must not be masked."""
+        cmd = 'git commit -m "ok" && git commit -F /tmp/msg.txt'
+        assert self._filter().classify_message_delivery(cmd) == "unscannable"
+
+    # --- option terminator (CodeRabbit): tokens after -- are pathspecs, not message flags ---
+
+    def test_file_flag_after_double_dash_is_not_a_message_flag(self):
+        """git commit -- -F : '-F' is a pathspec here, not a message source -> none."""
+        assert self._filter().classify_message_delivery("git commit -- -F") == "none"
+
+    def test_long_file_flag_after_double_dash_is_not_a_message_flag(self):
+        """git commit -- --file : '--file' is a pathspec here -> none."""
+        assert self._filter().classify_message_delivery("git commit -- --file") == "none"
 
 
 class TestUnscannableMessageAction:

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -30,6 +30,7 @@ skip_in_ci = pytest.mark.skipif(_IN_CI, reason="Timing tests are flaky in CI env
 import pre_tool_use
 from pre_tool_use import format_message, get_validator, handle_pre_tool_use, map_risk_to_status
 from schlock import RiskLevel, ValidationResult
+from schlock.integrations.commit_filter import CommitMessageFilter
 
 
 class TestStatusMapping:
@@ -495,3 +496,76 @@ class TestSelfProtectionHook:
         }
         response = handle_pre_tool_use(input_data)
         assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+class TestUnscannableMessageHookHandling:
+    """Hook-level warn/block/off handling for issue #76 unscannable commit messages.
+
+    A commit whose message is delivered outside argv (-F/--file, or -F - stdin) cannot be
+    scanned pre-execution. Per ``unscannable_message_action``: block -> deny before it runs;
+    warn -> allow but attach a model-visible note; off -> today's silent pass. Legitimate
+    message reuse (--amend --no-edit) and inline -m (even with an incidental $()) are never flagged.
+    """
+
+    @staticmethod
+    def _input(cmd):
+        return {"tool_name": "Bash", "tool_input": {"command": cmd}}
+
+    @staticmethod
+    def _filter(action):
+        return CommitMessageFilter({"enabled": True, "rules": {}, "unscannable_message_action": action})
+
+    @patch("pre_tool_use.get_filter")
+    def test_unscannable_block_denies(self, mock_get_filter):
+        """action=block -> a file-delivered message is denied before execution."""
+        mock_get_filter.return_value = self._filter("block")
+        response = handle_pre_tool_use(self._input("git commit -F /tmp/msg.txt"))
+        hso = response["hookSpecificOutput"]
+        assert hso["permissionDecision"] == "deny"
+        assert hso["permissionDecisionReason"]  # explains the reason
+
+    @patch("pre_tool_use.get_filter")
+    def test_unscannable_warn_allows_with_context(self, mock_get_filter):
+        """action=warn -> allowed (not blocked) with a model-visible additionalContext note."""
+        mock_get_filter.return_value = self._filter("warn")
+        response = handle_pre_tool_use(self._input("git commit -F /tmp/msg.txt"))
+        hso = response["hookSpecificOutput"]
+        assert hso["permissionDecision"] != "deny"
+        assert "additionalContext" in hso
+        assert "scan" in hso["additionalContext"].lower()
+
+    @patch("pre_tool_use.get_filter")
+    def test_unscannable_off_allows_silently(self, mock_get_filter):
+        """action=off -> allowed with no note (preserves today's silent behavior)."""
+        mock_get_filter.return_value = self._filter("off")
+        response = handle_pre_tool_use(self._input("git commit -F /tmp/msg.txt"))
+        hso = response["hookSpecificOutput"]
+        assert hso["permissionDecision"] != "deny"
+        assert "additionalContext" not in hso
+
+    @patch("pre_tool_use.get_filter")
+    def test_stdin_warn_allows_with_context(self, mock_get_filter):
+        """git commit -F - (stdin) under warn -> allowed with a note."""
+        mock_get_filter.return_value = self._filter("warn")
+        response = handle_pre_tool_use(self._input("git commit -F -"))
+        hso = response["hookSpecificOutput"]
+        assert hso["permissionDecision"] != "deny"
+        assert "additionalContext" in hso
+
+    @patch("pre_tool_use.get_filter")
+    def test_inline_substitution_not_flagged(self, mock_get_filter):
+        """-m "$(cat externalfile)" is scannable (literal in argv) -> no unscannable note."""
+        mock_get_filter.return_value = self._filter("block")
+        response = handle_pre_tool_use(self._input('git commit -m "$(cat /tmp/msg.txt)"'))
+        hso = response["hookSpecificOutput"]
+        assert hso["permissionDecision"] != "deny"
+        assert "additionalContext" not in hso
+
+    @patch("pre_tool_use.get_filter")
+    def test_amend_reuse_not_flagged_even_when_block(self, mock_get_filter):
+        """Legit reuse (--amend --no-edit) is never warned/blocked, even at the strictest action."""
+        mock_get_filter.return_value = self._filter("block")
+        response = handle_pre_tool_use(self._input("git commit --amend --no-edit"))
+        hso = response["hookSpecificOutput"]
+        assert hso["permissionDecision"] != "deny"
+        assert "additionalContext" not in hso

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -569,3 +569,30 @@ class TestUnscannableMessageHookHandling:
         hso = response["hookSpecificOutput"]
         assert hso["permissionDecision"] != "deny"
         assert "additionalContext" not in hso
+
+    @patch("pre_tool_use.get_filter")
+    def test_warn_still_validates_rest_of_command(self, mock_get_filter):
+        """Under warn the command is NOT auto-allowed: a dangerous tail is still validated.
+
+        Guards the security property that the warn note rides the FINAL decision rather than
+        short-circuiting with an early allow. `rm -rf /` is BLOCKED in every preset, so the
+        compound command must deny regardless of local risk-tolerance config.
+        """
+        mock_get_filter.return_value = self._filter("warn")
+        response = handle_pre_tool_use(self._input("git commit -F /tmp/msg.txt && rm -rf /"))
+        assert response["hookSpecificOutput"]["permissionDecision"] in {"ask", "deny"}
+
+    @patch("pre_tool_use.get_audit_logger")
+    @patch("pre_tool_use.get_filter")
+    def test_block_audit_violation_is_distinct_not_advertising(self, mock_get_filter, mock_get_audit):
+        """A block on an unscannable message must NOT be audit-logged as 'Advertising' (we do
+        not know there is a trailer); it needs its own violation type for clean audit data."""
+        mock_get_filter.return_value = self._filter("block")
+        mock_audit = mock_get_audit.return_value
+        handle_pre_tool_use(self._input("git commit -F /tmp/msg.txt"))
+        block_calls = [c for c in mock_audit.log_validation.call_args_list if c.kwargs.get("decision") == "block"]
+        assert block_calls, "expected a block audit entry"
+        violations = block_calls[-1].kwargs["violations"]
+        joined = " ".join(violations).lower()
+        assert "advertising" not in joined  # not mislabeled
+        assert "unscannable" in joined  # distinct, descriptive type

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -15,6 +15,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -596,3 +597,18 @@ class TestUnscannableMessageHookHandling:
         joined = " ".join(violations).lower()
         assert "advertising" not in joined  # not mislabeled
         assert "unscannable" in joined  # distinct, descriptive type
+
+    @patch("pre_tool_use.get_audit_logger")
+    @patch("pre_tool_use.validate_command", return_value=SimpleNamespace(error="boom"))
+    @patch("pre_tool_use.get_filter")
+    def test_warn_marker_recorded_on_validation_error_deny(self, mock_get_filter, _mock_validate, mock_get_audit):
+        """A warn-classified unscannable command that then hits a validation-error deny must
+        still record the unscannable detection in the audit entry (audit captures all decisions),
+        not just on the happy allow/ask path."""
+        mock_get_filter.return_value = self._filter("warn")
+        mock_audit = mock_get_audit.return_value
+        handle_pre_tool_use(self._input("git commit -F /tmp/msg.txt"))
+        block_calls = [c for c in mock_audit.log_validation.call_args_list if c.kwargs.get("decision") == "block"]
+        assert block_calls, "expected a block audit entry on validation error"
+        joined = " ".join(block_calls[-1].kwargs["violations"]).lower()
+        assert "unscannable" in joined  # warn detection survives the error-deny path


### PR DESCRIPTION
## Summary

The advertising blocker scans the **Bash command string**. When a commit message is delivered from *outside* argv — `git commit -F <file>` / `--file=`, or stdin (`-F -`) — the content is never in the command, so it slips through unscanned (issue #76). Adding more antispam patterns can't help; the message never reaches them.

This PR adds **pre-execution warn/block** for those forms, without trying to read the referenced file (a deliberately rejected approach — see below).

## What changed

- **`classify_message_delivery()`** — classifies a git commit into:
  - `scannable` — a message extracted from argv (any `-m "..."`), scanned as-is;
  - `unscannable` — delivered via `-F`/`--file`/stdin (content not in argv);
  - `none` — no *new* author-supplied content (`--amend --no-edit`, `-C`/`-c`, `--squash`/`--fixup`, `--template`, bare `git commit`).
- **`unscannable_message_action`** config (`off` | `warn` | `block`, default **`warn`**):
  - `warn` → allow, but attach a model-visible `additionalContext` note (rides the final decision, so safety validation of the rest of the command is **not** short-circuited);
  - `block` → deny up front;
  - `off` → prior silent pass-through.
- Hook (`pre_tool_use.py`) honors the decision; `FilterResult` gains `message_delivery` / `unscannable_decision` / `unscannable_reason`.

## Why these choices

- **`warn` default, not `block`.** The bare `None`-extraction signal is *overloaded*: `--amend --no-edit`, `-C HEAD` (legitimate reuse) **and** `-F file` (#76) all extract to `None`. Blocking on `None` would deny every amend/reuse. The classifier separates "no new content" (never flag) from "content not in argv" (warn/block).
- **The filter never reads the `-F`/`--file` target.** Resolving an agent-supplied path introduces TOCTOU, symlink/FIFO hazards, and hook-cwd-vs-git-cwd ambiguity for a *cosmetic, fail-open* filter. Warn/block is the honest pre-execution boundary.
- **Inline `-m` stays scannable even with an incidental `$(...)`.** An earlier iteration flagged any `-m` containing a substitution as unscannable; review caught that this **regressed** the core blocker (a message like `-m "Deploy $(date)\n\nCo-Authored-By: ..."` has a literal trailer in argv that *was* being stripped). If any literal is in argv, we scan it.

## Testing

- 39 new tests (delivery classification, action policy, hook warn/block, DoS size-guard, regression guards).
- Full suite green except pre-existing, unrelated `high-risk-ask` / benchmark-CLI failures (reproduce on `main`).
- `ruff check` + `ruff format` clean.

## Scope / follow-up

This is the **pre-execution** half of #76. Deliberately **not** in scope here (tracked separately):

- `gh pr create --body-file` / `gh issue create` — `gh` is outside the commit-filter's recognizer.
- `-m "$(cat externalfile)"` where the *whole* message is a substitution — its literal `$(...)` text is in argv (scanned, matches nothing), so it slips; there is genuinely nothing to scan pre-execution.

The durable fix for all of the above is a **post-commit (`PostToolUse`) check** that reads the actual committed message (`git log -1 --format=%B`) and feeds a detected trailer back to the model to amend. That's a follow-up.

Refs #76.
