### PR TITLE
fix(commit-filter): extract git commit --message / --message= long flag (#77)

### DIFF
--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -490,28 +490,26 @@ class CommitMessageFilter:
         if heredoc_match:
             return heredoc_match.group(1)
 
-        # Pattern 2: Standard quoted message - -m "msg", --message 'msg', --message="msg"
-        # Use finditer to get ALL message flags (prevents bypass via multiple flags)
-        # Note: This pattern doesn't handle escaped quotes well - bashlex is preferred
-        matches = list(re.finditer(rf'{_MSG_FLAG}(["\'])(.+?)\1', command, re.DOTALL))
-
-        if matches:
-            # Extract all messages and combine with paragraph breaks
-            messages = [m.group(2).replace("\\n", "\n") for m in matches]
+        # Pattern 2: every message value, in ONE left-to-right pass so quoted AND unquoted
+        # attached forms AGGREGATE in argv order. A single pass (rather than separate quoted /
+        # empty / unquoted searches with early returns) is what makes mixed commands like
+        # `--message="clean" --message=adtoken` keep BOTH paragraphs (#77, CodeRabbit #81) — a
+        # quoted flag must not short-circuit and drop a later unquoted token. Two alternatives:
+        #   - quoted (any flag):      -m "x" / --message 'x' / --message="x"  (group 2 = value;
+        #     .*? also matches the empty message ""). The quoted span is consumed as a UNIT, so a
+        #     literal --message= INSIDE a value cannot be re-matched as an attached flag.
+        #   - unquoted attached long: --message=word (group 3). The first char is non-quote so it
+        #     never swallows an empty "" (left to the quoted branch), and -m stays strict (no
+        #     unquoted -m) — preserving existing -m behavior byte-for-byte.
+        # Escaped quotes inside a value remain imperfect here; bashlex is preferred and tried first.
+        combined = re.compile(rf'{_MSG_FLAG}(["\'])(.*?)\1' + r'|--message=([^\s"\']\S*)', re.DOTALL)
+        messages = []
+        for m in combined.finditer(command):
+            value = m.group(2) if m.group(2) is not None else m.group(3)
+            if value is not None:
+                messages.append(value.replace("\\n", "\n"))
+        if messages:
             return "\n\n".join(messages)
-
-        # Pattern 3: Empty message -m "" / --message=""
-        empty_match = re.search(rf'{_MSG_FLAG}(["\'])\1', command)
-        if empty_match:
-            return ""
-
-        # Pattern 4: --message=word with an UNQUOTED single-token value (#77). Quoted forms are
-        # caught above; this is the bare attached token. Collect ALL such tokens (findall, not
-        # search) for parity with Pattern 2 — otherwise a single-token ad in a later flag (e.g.
-        # `--message=ok --message=claude.com/claude-code`) would slip the regex fallback.
-        attached = re.findall(r"--message=(\S+)", command)
-        if attached:
-            return "\n\n".join(a.replace("\\n", "\n") for a in attached)
 
         # No message found
         return None

--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -42,6 +42,20 @@ logger = logging.getLogger(__name__)
 # Size limit to prevent DoS via huge commands (64KB is generous for commit messages)
 MAX_COMMAND_SIZE = 64 * 1024
 
+# Long form of the -m commit-message flag (issue #77). The blockable content sits in argv for
+# --message "msg" / --message=msg just as it does for -m, but the extractor used to key on -m
+# only, so these slipped (fail-open). git ALSO accepts unambiguous prefixes (--mess, --messa);
+# those are intentionally NOT handled - no agent emits abbreviated flags and this is a fail-open
+# cosmetic filter, not a security boundary (see CLAUDE.md / test_abbreviated_long_flag_*).
+_LONG_MESSAGE_FLAG = "--message"
+_ATTACHED_LONG_PREFIX = _LONG_MESSAGE_FLAG + "="  # "--message="
+
+# Regex fragment matching the flag+separator preceding a commit-message value. Shared by the
+# regex extraction fallback and command reconstruction so the two never drift:
+#   -m<ws>           kept strict with \s+ so existing -m behavior is byte-for-byte unchanged
+#   --message<ws>    or   --message=
+_MSG_FLAG = r"(?:-m\s+|--message(?:\s+|=))"
+
 
 @dataclass(frozen=True)
 class FilterResult:
@@ -402,6 +416,25 @@ class CommitMessageFilter:
             # Fallback to bashlex-parsed word
             return msg_node.word.replace("\\n", "\n")
 
+        def extract_attached_message(flag_node: Any) -> str:
+            """Extract the value of a single --message=VALUE token (issue #77).
+
+            Uses raw position slicing rather than flag_node.word for the same reason
+            extract_msg_from_node does: bashlex drops the backslash of a literal \\n in .word,
+            which would corrupt a multi-line trailer. We slice the original command, strip the
+            ``--message=`` prefix, then strip a matched surrounding quote.
+            """
+            if hasattr(flag_node, "pos"):
+                start, end = flag_node.pos
+                raw = command[start:end]
+                value = raw[len(_ATTACHED_LONG_PREFIX) :] if raw.startswith(_ATTACHED_LONG_PREFIX) else ""
+                if value and value[0] in "\"'" and value[-1] == value[0]:
+                    value = value[1:-1]
+                return value.replace("\\n", "\n")
+            # Fallback: bashlex word (loses a literal \\n backslash, acceptable when pos absent)
+            word = flag_node.word
+            return word[len(_ATTACHED_LONG_PREFIX) :].replace("\\n", "\n") if word.startswith(_ATTACHED_LONG_PREFIX) else ""
+
         def visit(node: Any) -> None:
             """Recursively visit AST nodes to find git commit messages."""
             if hasattr(node, "kind") and node.kind == "command":
@@ -411,10 +444,15 @@ class CommitMessageFilter:
                 if len(words) >= 2 and words[0].word == "git" and words[1].word == "commit":
                     i = 0
                     while i < len(words):
-                        word_node = words[i]
-                        if word_node.word == "-m" and i + 1 < len(words):
+                        word = words[i].word
+                        if word in ("-m", _LONG_MESSAGE_FLAG) and i + 1 < len(words):
+                            # Separate-word form: -m "msg" / --message "msg". Value is next token.
                             messages.append(extract_msg_from_node(words[i + 1]))
-                            i += 2  # Skip past -m and message
+                            i += 2  # Skip past the flag and its message
+                        elif word.startswith(_ATTACHED_LONG_PREFIX):
+                            # Attached form: --message="msg" / --message=word (single token).
+                            messages.append(extract_attached_message(words[i]))
+                            i += 1
                         else:
                             i += 1
 
@@ -447,25 +485,32 @@ class CommitMessageFilter:
             Extracted message or None if not found
         """
         # Pattern 1: Heredoc format (check FIRST - more specific pattern)
-        # Match: -m "$(cat <<'EOF'\nMESSAGE\nEOF\n)"
-        heredoc_match = re.search(r'-m\s+"?\$\(cat\s+<<\'EOF\'\n(.+?)\nEOF\n\)"?', command, re.DOTALL)
+        # Match: -m/--message "$(cat <<'EOF'\nMESSAGE\nEOF\n)"
+        heredoc_match = re.search(rf'{_MSG_FLAG}"?\$\(cat\s+<<\'EOF\'\n(.+?)\nEOF\n\)"?', command, re.DOTALL)
         if heredoc_match:
             return heredoc_match.group(1)
 
-        # Pattern 2: Standard -m "message" or -m 'message'
-        # Use finditer to get ALL -m flags (prevents bypass via multiple -m)
+        # Pattern 2: Standard quoted message - -m "msg", --message 'msg', --message="msg"
+        # Use finditer to get ALL message flags (prevents bypass via multiple flags)
         # Note: This pattern doesn't handle escaped quotes well - bashlex is preferred
-        matches = list(re.finditer(r'-m\s+(["\'])(.+?)\1', command, re.DOTALL))
+        matches = list(re.finditer(rf'{_MSG_FLAG}(["\'])(.+?)\1', command, re.DOTALL))
 
         if matches:
             # Extract all messages and combine with paragraph breaks
             messages = [m.group(2).replace("\\n", "\n") for m in matches]
             return "\n\n".join(messages)
 
-        # Pattern 3: Empty message -m ""
-        empty_match = re.search(r'-m\s+(["\'])\1', command)
+        # Pattern 3: Empty message -m "" / --message=""
+        empty_match = re.search(rf'{_MSG_FLAG}(["\'])\1', command)
         if empty_match:
             return ""
+
+        # Pattern 4: --message=word with an UNQUOTED single-token value (#77). Quoted forms are
+        # caught above; this is the bare attached token (cannot carry a multi-word trailer, but
+        # handled for completeness and parity with the bashlex path).
+        attached = re.search(r"--message=(\S+)", command)
+        if attached:
+            return attached.group(1).replace("\\n", "\n")
 
         # No message found
         return None
@@ -540,15 +585,16 @@ class CommitMessageFilter:
         # Convert actual newlines to literal \n for bash
         escaped_message = escaped_message.replace("\n", "\\n")
 
-        # Pattern to match -m with quoted string (double or single quotes)
-        m_pattern = re.compile(r'-m\s+(["\'])(.+?)\1', re.DOTALL)
+        # Pattern to match -m / --message / --message= with a quoted string (#77). Shares
+        # _MSG_FLAG with extraction so the two recognize exactly the same flag forms.
+        m_pattern = re.compile(rf'{_MSG_FLAG}(["\'])(.+?)\1', re.DOTALL)
 
-        # Find all -m arguments
+        # Find all message-flag arguments
         matches = list(m_pattern.finditer(original_command))
 
         if not matches:
-            # No -m found - shouldn't happen if we got here, but failsafe
-            logger.warning("No -m pattern found in command, cannot reconstruct")
+            # No message flag found - shouldn't happen if we got here, but failsafe
+            logger.warning("No -m/--message pattern found in command, cannot reconstruct")
             return original_command
 
         # Strategy: Replace first -m arg with cleaned message, remove subsequent -m args

--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -506,11 +506,12 @@ class CommitMessageFilter:
             return ""
 
         # Pattern 4: --message=word with an UNQUOTED single-token value (#77). Quoted forms are
-        # caught above; this is the bare attached token (cannot carry a multi-word trailer, but
-        # handled for completeness and parity with the bashlex path).
-        attached = re.search(r"--message=(\S+)", command)
+        # caught above; this is the bare attached token. Collect ALL such tokens (findall, not
+        # search) for parity with Pattern 2 — otherwise a single-token ad in a later flag (e.g.
+        # `--message=ok --message=claude.com/claude-code`) would slip the regex fallback.
+        attached = re.findall(r"--message=(\S+)", command)
         if attached:
-            return attached.group(1).replace("\\n", "\n")
+            return "\n\n".join(a.replace("\\n", "\n") for a in attached)
 
         # No message found
         return None
@@ -589,7 +590,14 @@ class CommitMessageFilter:
         # _MSG_FLAG with extraction so the two recognize exactly the same flag forms.
         m_pattern = re.compile(rf'{_MSG_FLAG}(["\'])(.+?)\1', re.DOTALL)
 
-        # Find all message-flag arguments
+        # KNOWN LIMITATION (CodeRabbit #81): matches are taken over the WHOLE original_command,
+        # so in a contrived compound command a `-m "..."` / `--message "..."` token OUTSIDE the
+        # git commit invocation could in principle be rewritten. This is deliberately NOT scoped
+        # to the git-commit segment because reconstruct_command's output (FilterResult.cleaned_
+        # command) is OFF the hook's block path: pre_tool_use.py denies on `patterns_removed` and
+        # never executes cleaned_command. Threading the extraction span through to here to scope
+        # the replacement would add machinery to a field nothing consumes (YAGNI). If a future
+        # caller ever EXECUTES cleaned_command, this must be scoped to the commit segment first.
         matches = list(m_pattern.finditer(original_command))
 
         if not matches:

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1193,6 +1193,23 @@ class TestLongMessageFlag:
         """Order preserved the other way too: unquoted before quoted keeps both, in order."""
         assert self._filter()._extract_via_regex('git commit --message=adtoken --message="clean"') == "adtoken\n\nclean"
 
+    def test_regex_fallback_mixed_preserves_ad_token_so_cleaner_catches_it(self):
+        """CodeRabbit #81 (r4) named example: `--message="ok" --message=claude.com/claude-code`.
+        The quoted flag must not short-circuit and drop the later UNQUOTED single-token ad URL —
+        the fallback keeps BOTH, so the cleaner still strips the ad (the bypass is closed end to
+        end, not merely at extraction)."""
+        rules = {
+            "advertising": {
+                "enabled": True,
+                "patterns": [{"pattern": r"claude\.com/claude-code", "description": "ad url", "replacement": ""}],
+            }
+        }
+        f = self._filter(rules=rules)
+        extracted = f._extract_via_regex('git commit --message="ok" --message=claude.com/claude-code')
+        assert extracted == "ok\n\nclaude.com/claude-code"  # both tokens preserved through the fallback
+        _, removed, _ = f.clean_message(extracted)
+        assert removed  # the preserved ad token is detected by the cleaner
+
     def test_regex_fallback_extracts_empty_long_flag(self):
         """_extract_via_regex returns '' for --message="" (Pattern 3)."""
         assert self._filter()._extract_via_regex('git commit --message=""') == ""

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1178,6 +1178,12 @@ class TestLongMessageFlag:
         here since the bashlex path otherwise masks it through the public API)."""
         assert self._filter()._extract_via_regex("git commit --message=fix") == "fix"
 
+    def test_regex_fallback_collects_multiple_unquoted_long_flags(self):
+        """CodeRabbit #81: Pattern 4 must collect ALL unquoted --message= tokens (parity with the
+        quoted Pattern 2), not just the first — else a single-token ad in a later flag slips the
+        regex fallback (e.g. --message=ok --message=claude.com/claude-code)."""
+        assert self._filter()._extract_via_regex("git commit --message=first --message=second") == "first\n\nsecond"
+
     def test_regex_fallback_extracts_empty_long_flag(self):
         """_extract_via_regex returns '' for --message="" (Pattern 3)."""
         assert self._filter()._extract_via_regex('git commit --message=""') == ""

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1205,6 +1205,65 @@ EOF
         assert result.message_delivery == "scannable"
         assert result.patterns_removed
 
+    # --- compound commands (git commit --message after &&/;) (CodeRabbit #81) ---
+    # The -m path has compound coverage (TestMessageExtraction); these give the long flag parity
+    # so a classifier/extraction regression on a compound segment cannot pass CI.
+
+    def test_compound_attached_long_flag_trailer_is_caught(self):
+        """git add . && git commit --message="...trailer" is scanned and blocked."""
+        cmd = 'git add . && git commit --message="feat: thing\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    def test_compound_separate_long_flag_trailer_is_caught(self):
+        """git add . && git commit --message "...trailer" (space-separated) is scanned and blocked."""
+        cmd = 'git add . && git commit --message "feat: thing\\n\\n🤖 Generated with Claude Code"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    def test_clean_compound_long_flag_message_is_not_flagged(self):
+        """A clean --message in a compound command is scannable, unmodified, not flagged."""
+        cmd = 'git add . && git commit --message="feat: clean compound"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert not result.patterns_removed
+        assert not result.was_modified
+
+    # --- security edge cases: escaped quotes / backslashes / multiple long flags (CodeRabbit #81) ---
+    # Parity with the -m edge cases in TestBashlexEdgeCases. Escaped-quote handling is imperfect
+    # for both flags, so (like test_nested_escaped_quotes) these assert loosely on substrings.
+
+    def test_long_flag_separate_escaped_quotes(self):
+        """--message "with \\"quotes\\"" extracts a non-None message containing the inner text."""
+        msg = self._filter().extract_commit_message(r'git commit --message "Message with \"escaped\" quotes"')
+        assert msg is not None
+        assert "escaped" in msg
+
+    def test_long_flag_attached_escaped_quotes(self):
+        """--message="with \\"quotes\\"" extracts a non-None message containing the inner text."""
+        msg = self._filter().extract_commit_message(r'git commit --message="Message with \"escaped\" quotes"')
+        assert msg is not None
+        assert "escaped" in msg
+
+    def test_long_flag_attached_backslashes(self):
+        """--message="Path: C:\\\\Users\\\\test" (backslashes) extracts without crashing."""
+        msg = self._filter().extract_commit_message(r'git commit --message="Path: C:\\Users\\test"')
+        assert msg is not None
+
+    def test_multiple_long_flags_combined(self):
+        """Two --message flags combine into paragraphs, like multiple -m."""
+        msg = self._filter().extract_commit_message('git commit --message="first" --message="second"')
+        assert msg == "first\n\nsecond"
+
+    def test_multiple_long_flags_trailer_in_second_is_caught(self):
+        """Extraction-bypass guard: a trailer in the SECOND --message is still scanned/blocked."""
+        cmd = 'git commit --message="feat: clean" --message="Co-Authored-By: Claude <noreply@anthropic.com>"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
     # --- documented residual (NOT a fix; pins current behavior so a future change is deliberate) ---
 
     def test_abbreviated_long_flag_is_known_residual_gap(self):

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -995,3 +995,220 @@ class TestUnscannableMessageAction:
         assert result.message_delivery == "scannable"
         assert result.patterns_removed  # the literal trailer IS caught despite the $(date)
         assert result.unscannable_decision is None
+
+
+class TestLongMessageFlag:
+    """Issue #77: ``git commit --message`` / ``--message=`` deliver the message in argv, but
+    the extractor only recognized ``-m`` - so advertising trailers supplied via the long flag
+    slipped through (fail-open). The message bytes ARE in the command, so this is a plain
+    extraction gap (distinct from #76, where content lives in a file/stdin). Both extraction
+    paths and command reconstruction must recognize the long flag.
+
+    Scope note: abbreviated long flags (``--mess``, ``--messa``) are git-valid unambiguous
+    prefixes of ``--message`` but are NOT covered - no agent emits abbreviated flags and this
+    is a fail-open cosmetic filter, not a security boundary. See ``test_abbreviated_long_flag_
+    is_known_residual_gap`` which documents the residual.
+    """
+
+    # Real Claude co-author trailer pattern, mirroring data/commit_filter_rules.yaml so these
+    # tests exercise the production rule rather than a toy stand-in.
+    CLAUDE_TRAILER_RULES = {
+        "advertising": {
+            "enabled": True,
+            "patterns": [
+                {
+                    "pattern": "\\n*Co-Authored-By:.*(?:Claude|@anthropic\\.com).*\\n*",
+                    "description": "Claude co-author trailer",
+                    "replacement": "\n",
+                },
+                {
+                    "pattern": "\\n*🤖.*Generated with.*\\n*",
+                    "description": "robot-emoji generation notice",
+                    "replacement": "\n",
+                },
+            ],
+        }
+    }
+
+    @staticmethod
+    def _filter(rules=None):
+        return CommitMessageFilter({"enabled": True, "rules": rules or {}})
+
+    # --- extraction: separate-word long flag (--message "msg") ---
+
+    def test_extracts_long_flag_separate_double_quoted(self):
+        """--message "msg" (space-separated, double-quoted) is extracted like -m."""
+        msg = self._filter().extract_commit_message('git commit --message "hello world"')
+        assert msg == "hello world"
+
+    def test_extracts_long_flag_separate_single_quoted(self):
+        """--message 'msg' (space-separated, single-quoted) is extracted."""
+        msg = self._filter().extract_commit_message("git commit --message 'hello world'")
+        assert msg == "hello world"
+
+    def test_extracts_long_flag_separate_with_literal_newlines(self):
+        """--message "L1\\nL2" converts literal \\n to real newlines like -m does."""
+        msg = self._filter().extract_commit_message('git commit --message "Line 1\\nLine 2"')
+        assert msg == "Line 1\nLine 2"
+
+    # --- extraction: attached long flag (--message=msg) ---
+
+    def test_extracts_long_flag_attached_double_quoted(self):
+        """--message="msg" (attached, =) strips the flag prefix and the quotes."""
+        msg = self._filter().extract_commit_message('git commit --message="hello world"')
+        assert msg == "hello world"
+
+    def test_extracts_long_flag_attached_single_quoted(self):
+        """--message='msg' (attached, single-quoted) is extracted."""
+        msg = self._filter().extract_commit_message("git commit --message='hello world'")
+        assert msg == "hello world"
+
+    def test_extracts_long_flag_attached_unquoted(self):
+        """--message=word (attached, no quotes - single shell token) is extracted."""
+        msg = self._filter().extract_commit_message("git commit --message=fix")
+        assert msg == "fix"
+
+    def test_extracts_long_flag_attached_with_literal_newlines(self):
+        """--message="L1\\nL2" must preserve \\n via raw-position slicing (not bashlex .word,
+        which drops the backslash). This is the load-bearing case for multi-line trailers."""
+        msg = self._filter().extract_commit_message('git commit --message="Line 1\\nLine 2"')
+        assert msg == "Line 1\nLine 2"
+
+    # --- extraction: mixed short + long flags accumulate in order ---
+
+    def test_mixed_short_then_long_combined(self):
+        """git commit -m "a" --message "b" combines both into one message."""
+        msg = self._filter().extract_commit_message('git commit -m "first" --message "second"')
+        assert msg == "first\n\nsecond"
+
+    def test_mixed_long_then_short_combined(self):
+        """git commit --message "a" -m "b" combines both in argv order."""
+        msg = self._filter().extract_commit_message('git commit --message "first" -m "second"')
+        assert msg == "first\n\nsecond"
+
+    def test_mixed_attached_long_and_short_combined(self):
+        """--message="a" mixed with -m "b" - all segments scanned."""
+        msg = self._filter().extract_commit_message('git commit --message="first" -m "second"')
+        assert msg == "first\n\nsecond"
+
+    # --- classification: long-flag messages are scannable (content is in argv) ---
+
+    def test_long_flag_separate_is_scannable(self):
+        """--message "x" content is literally in argv -> scannable."""
+        assert self._filter().classify_message_delivery('git commit --message "fix: a bug"') == "scannable"
+
+    def test_long_flag_attached_is_scannable(self):
+        """--message="x" content is literally in argv -> scannable."""
+        assert self._filter().classify_message_delivery('git commit --message="fix: a bug"') == "scannable"
+
+    def test_long_flag_with_incidental_substitution_is_scannable(self):
+        """--message="Deploy $(date)" - the literal $(...) text is in argv -> scannable
+        (consistent with the -m invariant; pre-exec substitution detection is #79, not here)."""
+        assert self._filter().classify_message_delivery('git commit --message="Deploy $(date)"') == "scannable"
+
+    # --- end-to-end: the trailer that prompted #77 no longer slips ---
+
+    def test_attached_long_flag_trailer_is_caught(self):
+        """THE #77 fix: --message="...Co-Authored-By: Claude..." is now blocked (patterns_removed)."""
+        cmd = 'git commit --message="feat: thing\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed  # hook denies on this
+
+    def test_separate_long_flag_trailer_is_caught(self):
+        """--message "...🤖 Generated with..." (space-separated) is now blocked."""
+        cmd = 'git commit --message "feat: thing\\n\\n🤖 Generated with Claude Code"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    def test_clean_long_flag_message_is_not_flagged(self):
+        """A clean --message commit is scannable, unmodified, and never flagged."""
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message('git commit --message="feat: clean"')
+        assert result.message_delivery == "scannable"
+        assert not result.patterns_removed
+        assert not result.was_modified
+
+    # --- reconstruct_command: the long flag must be rewritten, not left dirty ---
+
+    def test_reconstructs_separate_long_flag(self):
+        """reconstruct_command rewrites --message "dirty" with the cleaned message."""
+        out = self._filter().reconstruct_command('git commit --message "dirty message"', "cleaned")
+        assert "cleaned" in out
+
+    def test_reconstructs_attached_long_flag(self):
+        """reconstruct_command rewrites --message="dirty" with the cleaned message."""
+        out = self._filter().reconstruct_command('git commit --message="dirty message"', "cleaned")
+        assert "cleaned" in out
+
+    def test_reconstruct_long_flag_drops_original_dirty_text(self):
+        """Latent-bug guard: reconstruct used to return the ORIGINAL command verbatim when no
+        -m was present, leaking the dirty text. The removed content must NOT survive."""
+        out = self._filter().reconstruct_command('git commit --message "REMOVE_ME keep"', "keep")
+        assert "REMOVE_ME" not in out
+        assert "keep" in out
+
+    # --- regression: short -m behavior is byte-for-byte unchanged by the shared fragment ---
+
+    def test_short_flag_extraction_unchanged(self):
+        """Refactor guard: plain -m "x" still extracts exactly "x"."""
+        assert self._filter().extract_commit_message('git commit -m "x"') == "x"
+
+    def test_short_flag_equals_not_treated_as_attached_message(self):
+        """Refactor guard: -m=foo must NOT be newly captured (the shared fragment keeps -m
+        strict with \\s+, so attached-short forms behave exactly as before: not extracted)."""
+        assert self._filter().extract_commit_message("git commit -m=foo") is None
+
+    # --- regex fallback path (bashlex bypassed) ---
+    # extract_commit_message tries bashlex first and returns before the regex fallback for any
+    # well-formed command, so the new --message handling in _extract_via_regex is NOT reached by
+    # the other tests. These target the fallback directly (and via heredocs, which make bashlex
+    # raise) so a regression in the shared _MSG_FLAG fragment cannot pass CI silently.
+
+    def test_regex_fallback_extracts_quoted_long_flag(self):
+        """_extract_via_regex handles --message "msg" (Pattern 2)."""
+        assert self._filter()._extract_via_regex('git commit --message "hi there"') == "hi there"
+
+    def test_regex_fallback_extracts_attached_long_flag(self):
+        """_extract_via_regex handles --message="msg" (Pattern 2 with =)."""
+        assert self._filter()._extract_via_regex('git commit --message="hi there"') == "hi there"
+
+    def test_regex_fallback_extracts_unquoted_attached_long_flag(self):
+        """_extract_via_regex handles --message=word (Pattern 4 - the new branch, guarded ONLY
+        here since the bashlex path otherwise masks it through the public API)."""
+        assert self._filter()._extract_via_regex("git commit --message=fix") == "fix"
+
+    def test_regex_fallback_extracts_empty_long_flag(self):
+        """_extract_via_regex returns '' for --message="" (Pattern 3)."""
+        assert self._filter()._extract_via_regex('git commit --message=""') == ""
+
+    def test_heredoc_long_flag_drives_regex_fallback(self):
+        """A --message heredoc makes bashlex raise, so the public API must extract via the regex
+        fallback (Pattern 1) - the realistic load-bearing form for this path."""
+        heredoc_cmd = """git commit --message "$(cat <<'EOF'
+Multi-line
+message
+EOF
+)\""""
+        assert self._filter().extract_commit_message(heredoc_cmd) == "Multi-line\nmessage"
+
+    def test_heredoc_long_flag_trailer_is_caught(self):
+        """End-to-end through the regex fallback: a --message heredoc carrying a Claude trailer
+        is still blocked (patterns_removed). Proves #77 closes for the heredoc long-flag form."""
+        heredoc_cmd = """git commit --message "$(cat <<'EOF'
+feat: thing
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)\""""
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(heredoc_cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    # --- documented residual (NOT a fix; pins current behavior so a future change is deliberate) ---
+
+    def test_abbreviated_long_flag_is_known_residual_gap(self):
+        """--mess (a git-valid unambiguous prefix of --message) is intentionally NOT extracted.
+        Documented residual: out of scope for #77, not worth gold-plating a fail-open cosmetic
+        filter. If this ever changes, it should be a deliberate decision, not an accident."""
+        assert self._filter().extract_commit_message('git commit --mess "abbrev"') is None

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1184,6 +1184,15 @@ class TestLongMessageFlag:
         regex fallback (e.g. --message=ok --message=claude.com/claude-code)."""
         assert self._filter()._extract_via_regex("git commit --message=first --message=second") == "first\n\nsecond"
 
+    def test_regex_fallback_mixed_quoted_and_unquoted_long_flags(self):
+        """CodeRabbit #81 (r4): a quoted --message must NOT short-circuit the fallback and drop a
+        later UNQUOTED --message= token — both are kept, in argv order."""
+        assert self._filter()._extract_via_regex('git commit --message="clean" --message=adtoken') == "clean\n\nadtoken"
+
+    def test_regex_fallback_unquoted_then_quoted_long_flags(self):
+        """Order preserved the other way too: unquoted before quoted keeps both, in order."""
+        assert self._filter()._extract_via_regex('git commit --message=adtoken --message="clean"') == "adtoken\n\nclean"
+
     def test_regex_fallback_extracts_empty_long_flag(self):
         """_extract_via_regex returns '' for --message="" (Pattern 3)."""
         assert self._filter()._extract_via_regex('git commit --message=""') == ""

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1210,18 +1210,26 @@ EOF
     # so a classifier/extraction regression on a compound segment cannot pass CI.
 
     def test_compound_attached_long_flag_trailer_is_caught(self):
-        """git add . && git commit --message="...trailer" is scanned and blocked."""
+        """git add . && git commit --message="...trailer" is scanned and blocked, and the
+        `git add . &&` prefix survives reconstruction (only the trailer is removed)."""
         cmd = 'git add . && git commit --message="feat: thing\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>"'
         result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
         assert result.message_delivery == "scannable"
         assert result.patterns_removed
+        assert result.was_modified
+        assert "git add . &&" in result.cleaned_command  # compound prefix preserved
+        assert "Co-Authored" not in result.cleaned_command  # trailer stripped
 
     def test_compound_separate_long_flag_trailer_is_caught(self):
-        """git add . && git commit --message "...trailer" (space-separated) is scanned and blocked."""
+        """git add . && git commit --message "...trailer" (space-separated) is scanned and
+        blocked, and the `git add . &&` prefix survives reconstruction."""
         cmd = 'git add . && git commit --message "feat: thing\\n\\n🤖 Generated with Claude Code"'
         result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
         assert result.message_delivery == "scannable"
         assert result.patterns_removed
+        assert result.was_modified
+        assert "git add . &&" in result.cleaned_command  # compound prefix preserved
+        assert "Generated with" not in result.cleaned_command  # trailer stripped
 
     def test_clean_compound_long_flag_message_is_not_flagged(self):
         """A clean --message in a compound command is scannable, unmodified, not flagged."""
@@ -1248,9 +1256,9 @@ EOF
         assert "escaped" in msg
 
     def test_long_flag_attached_backslashes(self):
-        """--message="Path: C:\\\\Users\\\\test" (backslashes) extracts without crashing."""
+        """--message="Path: C:\\\\Users\\\\test" preserves backslashes exactly (not corrupted)."""
         msg = self._filter().extract_commit_message(r'git commit --message="Path: C:\\Users\\test"')
-        assert msg is not None
+        assert msg == r"Path: C:\\Users\\test"
 
     def test_multiple_long_flags_combined(self):
         """Two --message flags combine into paragraphs, like multiple -m."""
@@ -1258,11 +1266,14 @@ EOF
         assert msg == "first\n\nsecond"
 
     def test_multiple_long_flags_trailer_in_second_is_caught(self):
-        """Extraction-bypass guard: a trailer in the SECOND --message is still scanned/blocked."""
+        """Extraction-bypass guard: a trailer in the SECOND --message is scanned/blocked, and the
+        clean FIRST paragraph survives (only the trailer paragraph is removed)."""
         cmd = 'git commit --message="feat: clean" --message="Co-Authored-By: Claude <noreply@anthropic.com>"'
         result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
         assert result.message_delivery == "scannable"
         assert result.patterns_removed
+        assert result.cleaned_message == "feat: clean"  # clean paragraph preserved
+        assert "Co-Authored" not in result.cleaned_message  # trailer removed
 
     # --- documented residual (NOT a fix; pins current behavior so a future change is deliberate) ---
 


### PR DESCRIPTION
## Summary

Closes the #77 fail-open gap. schlock's advertising filter recognised only `-m`, so an attribution/advertising trailer supplied via `git commit --message "..."` or `--message="..."` was never extracted and slipped straight through. Unlike #76 (content delivered via a file/stdin), the message **is** in argv here — a plain extraction bug, fully closeable.

## Changes (`src/schlock/integrations/commit_filter.py`)

- **`_extract_via_bashlex`** — recognises `--message <arg>` (separate token) and `--message=<arg>` (attached). The attached value is sliced from the raw command position (not bashlex `.word`) so a literal `\n` in a multi-line trailer survives, mirroring the existing `-m` rationale.
- **`_extract_via_regex`** (fallback) — a shared `_MSG_FLAG` fragment keeps `-m` byte-for-byte unchanged (strict `\s+`) and adds `--message`/`--message=`, plus a Pattern 4 for an unquoted `--message=value`.
- **`reconstruct_command`** — shares `_MSG_FLAG`, fixing a latent bug where a `--message` input returned the *dirty* original command while `was_modified=True`. (Off the hook's block path — the hook denies on `patterns_removed` — but fixed for internal consistency.)

## Scope / residual

Abbreviated long flags (`--mess`, `--messa`) are intentionally **not** handled — no agent emits abbreviated flags and this is a fail-open *cosmetic* filter, not a security boundary. Pinned by `test_abbreviated_long_flag_is_known_residual_gap`. File/stdin/substitution forms remain tracked by #76 / #79.

## Tests

New `TestLongMessageFlag` covers separate/attached/quoted/unquoted/newline/mixed extraction, delivery classification (scannable), end-to-end deny via the real bundled trailer pattern, reconstruction, and the regex **fallback** path directly (the second modified path — otherwise masked because bashlex wins for well-formed input). Full commit-filter suite: 122 passing; ruff lint + format clean.

Built test-first; reviewed via a multi-lens adversarial agent panel (the fallback-coverage tests above were a panel finding, then verified to fail against a deliberately-broken `_MSG_FLAG`).
