### PR TITLE
fix(commit-filter): recognize git global options before the commit subcommand (#82)

### DIFF
--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -42,6 +42,15 @@ logger = logging.getLogger(__name__)
 # Size limit to prevent DoS via huge commands (64KB is generous for commit messages)
 MAX_COMMAND_SIZE = 64 * 1024
 
+# git GLOBAL options that consume the FOLLOWING word as a value, in separate-word form (issue
+# #82). When one precedes the subcommand (e.g. `git -C <path> commit`), the next token is its
+# value, NOT the subcommand — so _commit_subcommand_index skips both. Everything else dashed is
+# treated as a value-less global flag (`-p`, `--no-pager`, `--bare`, …) or an attached-value
+# form (`--git-dir=…`), which consume only their own token.
+_GIT_GLOBAL_VALUE_OPTS = frozenset(
+    {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--config-env", "--attr-source"}
+)
+
 
 @dataclass(frozen=True)
 class FilterResult:
@@ -169,24 +178,61 @@ class CommitMessageFilter:
                 logger.warning(f"Invalid custom pattern: {e}. Skipping.")
                 continue
 
-    def is_git_commit_command(self, command: str) -> bool:
-        """Check if command contains a git commit.
+    @staticmethod
+    def _commit_subcommand_index(words: list[str]) -> int:
+        """Index of the ``commit`` subcommand within a git argv word list, tolerating leading git
+        GLOBAL options (issue #82): ``git -C <path> commit``, ``git -c k=v commit``,
+        ``git --git-dir=… commit``, ``git --work-tree … commit``, ``git --no-pager commit``.
 
-        Handles compound commands like:
+        Returns -1 if ``words`` is not a ``git … commit`` invocation. Fail-open bias: value-taking
+        globals (``-C`` etc., see _GIT_GLOBAL_VALUE_OPTS) consume their following word so a path is
+        never mistaken for the subcommand; any other dashed token is treated as a value-less flag.
+        """
+        if len(words) < 2 or words[0] != "git":
+            return -1
+        i = 1
+        while i < len(words):
+            word = words[i]
+            if word == "commit":
+                return i
+            if not word.startswith("-"):
+                return -1  # first non-option token is some other subcommand (status, log, push…)
+            if "=" in word or word not in _GIT_GLOBAL_VALUE_OPTS:
+                i += 1  # attached-value (--git-dir=…) or value-less flag — consume just this token
+            else:
+                i += 2  # separate-word value (e.g. -C <path>) — consume the option AND its value
+        return -1
+
+    def is_git_commit_command(self, command: str) -> bool:
+        """Check if the command contains a git commit invocation.
+
+        Handles compound commands AND git GLOBAL options before the subcommand (issue #82):
         - git commit -m "msg"
         - git add . && git commit -m "msg"
         - cd project && git add -A && git commit -m "msg"
-        - git add .; git commit -m "msg"
+        - git -C /path commit -m "msg"      (global option between `git` and `commit`)
+        - git -c key=val commit -m "msg"
 
         Args:
             command: Bash command string
 
         Returns:
-            True if command contains 'git commit'
+            True if any segment is a ``git [global-opts] commit`` invocation.
         """
-        # Check for 'git commit' anywhere in the command
-        # Use word boundary to avoid matching 'git-commit' or 'git_commit'
-        return bool(re.search(r"\bgit\s+commit\b", command))
+        # Fast reject: a git commit needs both "git" and a standalone "commit" token. Skips
+        # parsing the overwhelming majority of commands (which contain neither).
+        if "git" not in command or not re.search(r"\bcommit\b", command):
+            return False
+        # Oversized: skip bashlex (DoS guard) and use a tolerant regex.
+        if len(command) > MAX_COMMAND_SIZE:
+            return bool(re.search(r"\bgit\b.*?\bcommit\b", command, re.DOTALL))
+        # Precise: bashlex AST, tolerant of global options. AST detection also avoids the old
+        # `\bgit\s+commit\b` false positive on strings like `echo "git commit"`. A parse failure
+        # must not silently disable detection, so fall back to a tolerant regex (over-detect-safe).
+        try:
+            return bool(self._commit_arg_word_lists(command))
+        except Exception:  # noqa: BLE001 - bashlex raises various types; fail-open to regex
+            return bool(re.search(r"\bgit\b.*?\bcommit\b", command, re.DOTALL))
 
     def extract_commit_message(self, command: str) -> Optional[str]:
         """Extract commit message from git command using dual-mode parsing.
@@ -298,8 +344,8 @@ class CommitMessageFilter:
 
     def _command_has_file_content_flag(self, command: str) -> bool:
         """True if any git commit segment delivers its message from a file or stdin (-F/--file)."""
-        for words in self._git_commit_word_lists(command):
-            for word in words[2:]:  # skip "git commit"; flags follow the subcommand
+        for args in self._git_commit_arg_lists(command):  # args already start AFTER `commit`
+            for word in args:
                 if word == "--":
                     break  # everything after the option terminator is a pathspec, not a flag
                 if word == "--file" or word.startswith("--file="):
@@ -332,28 +378,22 @@ class CommitMessageFilter:
         "scanning, or remove any unwanted trailer manually."
     )
 
-    def _git_commit_word_lists(self, command: str) -> list[list[str]]:
-        """Return the argv word lists of every ``git commit`` invocation in the command.
+    def _commit_arg_word_lists(self, command: str) -> list[list[str]]:
+        """For each ``git … commit`` invocation, the argument words FOLLOWING ``commit`` (the
+        global options and the subcommand itself stripped). Tolerates global options between
+        ``git`` and ``commit`` via _commit_subcommand_index (issue #82).
 
-        Uses bashlex to isolate the git commit segment(s) of a compound command. On parse
-        failure (or an oversized command) falls back to splitting the whole command -
-        over-detecting a file flag and warning is safer than silently missing it for this
-        fail-open filter, and never parsing an oversized string avoids a DoS on the hook.
+        RAISES if bashlex cannot parse — callers decide the fallback. Callers must size-guard
+        before calling (no DoS check here).
         """
-        if len(command) > MAX_COMMAND_SIZE:  # DoS guard: never run bashlex on an oversized command
-            return [command.split()]
-        try:
-            parts = bashlex.parse(command)
-        except Exception:  # noqa: BLE001 - bashlex raises various types; fail-open to split
-            return [command.split()]
-
         results: list[list[str]] = []
 
         def visit(node: Any) -> None:
             if getattr(node, "kind", None) == "command":
                 words = [p.word for p in getattr(node, "parts", []) if hasattr(p, "word")]
-                if len(words) >= 2 and words[0] == "git" and words[1] == "commit":
-                    results.append(words)
+                idx = self._commit_subcommand_index(words)
+                if idx != -1:
+                    results.append(words[idx + 1 :])
             for attr in ("parts", "list", "command"):
                 child = getattr(node, attr, None)
                 if child is None:
@@ -361,9 +401,21 @@ class CommitMessageFilter:
                 for item in child if isinstance(child, list) else [child]:
                     visit(item)
 
-        for part in parts:
+        for part in bashlex.parse(command):
             visit(part)
+        return results
 
+    def _git_commit_arg_lists(self, command: str) -> list[list[str]]:
+        """_commit_arg_word_lists with fail-open fallbacks for the file-flag scan: on oversized
+        input, parse failure, or no match, return a single naive split of the whole command so a
+        file flag (-F/--file) is over-detected rather than silently missed.
+        """
+        if len(command) > MAX_COMMAND_SIZE:  # DoS guard: never run bashlex on an oversized command
+            return [command.split()]
+        try:
+            results = self._commit_arg_word_lists(command)
+        except Exception:  # noqa: BLE001 - bashlex raises various types; fail-open to split
+            return [command.split()]
         return results if results else [command.split()]
 
     def _extract_via_bashlex(self, command: str) -> Optional[str]:
@@ -407,9 +459,10 @@ class CommitMessageFilter:
             if hasattr(node, "kind") and node.kind == "command":
                 words = [p for p in getattr(node, "parts", []) if hasattr(p, "word")]
 
-                # Check if this is 'git commit'
-                if len(words) >= 2 and words[0].word == "git" and words[1].word == "commit":
-                    i = 0
+                # Check if this is 'git [global-opts] commit' (issue #82: tolerate -C/-c/etc.)
+                idx = self._commit_subcommand_index([w.word for w in words])
+                if idx != -1:
+                    i = idx + 1  # scan the commit's own args, starting AFTER the `commit` token
                     while i < len(words):
                         word_node = words[i]
                         if word_node.word == "-m" and i + 1 < len(words):

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -995,3 +995,108 @@ class TestUnscannableMessageAction:
         assert result.message_delivery == "scannable"
         assert result.patterns_removed  # the literal trailer IS caught despite the $(date)
         assert result.unscannable_decision is None
+
+
+class TestGitGlobalOptions:
+    """Issue #82: git accepts GLOBAL options between `git` and the `commit` subcommand
+    (`git -C <path> commit`, `git -c k=v commit`, `git --git-dir=… commit`, `git --work-tree …
+    commit`). The filter assumed adjacency (`git commit`), so these forms bypassed detection,
+    extraction, file-flag classification, and ultimately the advertising blocker entirely.
+    """
+
+    CLAUDE_TRAILER_RULES = {
+        "advertising": {
+            "enabled": True,
+            "patterns": [
+                {
+                    "pattern": "\\n*Co-Authored-By:.*(?:Claude|@anthropic\\.com).*\\n*",
+                    "description": "Claude co-author trailer",
+                    "replacement": "\n",
+                }
+            ],
+        }
+    }
+
+    @staticmethod
+    def _filter(rules=None):
+        return CommitMessageFilter({"enabled": True, "rules": rules or {}})
+
+    # --- detection: is_git_commit_command tolerates global options ---
+
+    def test_detects_chdir_option(self):
+        """git -C <path> commit is a git commit."""
+        assert self._filter().is_git_commit_command('git -C /tmp/r commit -m "x"')
+
+    def test_detects_dash_c_config(self):
+        """git -c key=val commit is a git commit (the value is not mistaken for the subcommand)."""
+        assert self._filter().is_git_commit_command('git -c user.name=Ada commit -m "x"')
+
+    def test_detects_git_dir_attached(self):
+        """git --git-dir=<dir> commit is a git commit."""
+        assert self._filter().is_git_commit_command('git --git-dir=/tmp/r/.g commit -m "x"')
+
+    def test_detects_work_tree_separate(self):
+        """git --work-tree <dir> commit (separate-word value) is a git commit."""
+        assert self._filter().is_git_commit_command('git --work-tree /tmp/r commit -m "x"')
+
+    def test_detects_valueless_global_flag(self):
+        """git --no-pager commit (value-less global flag) is a git commit."""
+        assert self._filter().is_git_commit_command('git --no-pager commit -m "x"')
+
+    def test_detects_global_options_in_compound(self):
+        """Compound command with a global-option git commit is detected."""
+        assert self._filter().is_git_commit_command('cd proj && git -C /tmp/r commit -m "x"')
+
+    # --- detection regressions: must NOT over-match ---
+
+    def test_chdir_option_with_non_commit_subcommand_is_not_a_commit(self):
+        """git -C <path> status is NOT a commit (the subcommand is status, not commit)."""
+        assert not self._filter().is_git_commit_command("git -C /tmp/r status")
+
+    def test_plain_forms_unchanged(self):
+        """Plain detection is unchanged by the global-option support."""
+        f = self._filter()
+        assert f.is_git_commit_command('git commit -m "x"')
+        assert not f.is_git_commit_command("git status")
+        assert not f.is_git_commit_command("git push")
+        assert not f.is_git_commit_command("ls -la")
+
+    # --- extraction through a global-option invocation ---
+
+    def test_extracts_message_with_chdir_option(self):
+        """The -m message is extracted from a git -C … commit invocation."""
+        assert self._filter().extract_commit_message('git -C /tmp/r commit -m "hello"') == "hello"
+
+    def test_extracts_multiple_m_with_global_config(self):
+        """Multiple -m flags still combine when global options precede commit."""
+        msg = self._filter().extract_commit_message('git -c core.editor=true commit -m "a" -m "b"')
+        assert msg == "a\n\nb"
+
+    # --- delivery classification ---
+
+    def test_global_option_inline_is_scannable(self):
+        assert self._filter().classify_message_delivery('git -C /tmp/r commit -m "x"') == "scannable"
+
+    def test_global_option_file_is_unscannable(self):
+        """git -C … commit -F file delivers from a file -> unscannable (was missed -> 'none')."""
+        assert self._filter().classify_message_delivery("git -C /tmp/r commit -F msg.txt") == "unscannable"
+
+    # --- end-to-end: the bypass is closed ---
+
+    def test_global_option_trailer_is_caught(self):
+        """THE #82 fix: git -C … commit -m "…trailer" is now scanned and blocked."""
+        cmd = 'git -C /tmp/r commit -m "feat: x\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+        result = self._filter(rules=self.CLAUDE_TRAILER_RULES).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    def test_global_option_file_warns(self):
+        """git -C … commit -F file triggers the #76 unscannable decision (default warn)."""
+        result = self._filter().filter_commit_message("git -C /tmp/r commit -F msg.txt")
+        assert result.message_delivery == "unscannable"
+        assert result.unscannable_decision == "warn"
+
+    # --- file-flag regression: plain form still detected ---
+
+    def test_plain_file_flag_still_unscannable(self):
+        assert self._filter().classify_message_delivery("git commit -F msg.txt") == "unscannable"


### PR DESCRIPTION
Closes #82.

## Problem

The commit filter assumed `git` is immediately followed by `commit`, so commits invoked with **git global options before the subcommand** bypassed scanning entirely — the advertising trailer committed cleanly:

| Form | before | after |
|---|---|---|
| `git commit -m "…trailer"` | blocked | blocked |
| `git -C <path> commit -m "…trailer"` | **slips** | **blocked** |
| `git -c k=v commit -m "…trailer"` | **slips** | **blocked** |
| `git --git-dir=… commit -m "…trailer"` | **slips** | **blocked** |
| `git -C <path> commit -F file` | **none** (no #76 warn) | **unscannable** (warns) |

The adjacency assumption lived in **four** places: `is_git_commit_command` (regex), `_extract_via_bashlex`, `_command_has_file_content_flag` (`words[2:]`), and the word-list helper.

## Fix

One shared helper — `_commit_subcommand_index(words)` — finds the `commit` subcommand tolerating leading global options (value-taking ones like `-C`/`-c`/`--git-dir`/`--work-tree` consume their following word via `_GIT_GLOBAL_VALUE_OPTS`; everything else dashed is value-less). Wired into all four sites:

- **`is_git_commit_command`** → bashlex-AST detection (fast-reject pre-check + tolerant-regex fallback on parse failure, preserving fail-open). Bonus: removes the old `\bgit\s+commit\b` false positive on strings like `echo "git commit"`.
- **`_extract_via_bashlex`** → scans `-m` starting after the `commit` index.
- **`_git_commit_arg_lists`** (renamed from `_git_commit_word_lists`) + **`_command_has_file_content_flag`** → scan the args that follow `commit`.

## Scope

- Distinct from #77/#81 (which fix the `--message` **extractor**); this is the **detector** one layer earlier, so #81 alone would not have closed it.
- `is_git_commit_command` is used **only** by the cosmetic, fail-open commit filter — not the safety validator (`core/parser.py`) — so this was an ad-blocker evasion, not a command-safety hole.

## Verification

- End-to-end through the hook: `git -C <path> commit -m "…Co-Authored-By: Claude…"` now returns **deny** (was **allow**).
- 15 new `TestGitGlobalOptions` cases (detection, classification, extraction, end-to-end block + `-F` warn, and regressions: `git -C … status` → not a commit, plain forms unchanged). 109 commit-filter tests pass; ruff lint + format clean.
