### PR TITLE
fix(commit-filter): case-insensitive, whitespace-tolerant advertising patterns (#85)

### DIFF
--- a/data/commit_filter_rules.yaml
+++ b/data/commit_filter_rules.yaml
@@ -26,36 +26,36 @@ rules:
     enabled: true  # Default: enabled (most users want clean commits)
     patterns:
       # Broad line-level patterns FIRST (prevent partial matches from mangling lines)
-      - pattern: "\\n*🤖.*Generated with.*\\n*"
+      - pattern: "(?i)\\n*🤖.*Generated\\s+with.*\\n*"
         description: "Any line with robot emoji and 'Generated with'"
         replacement: "\n"
 
-      - pattern: "\\n*Co-Authored-By:.*(?:Claude|@anthropic\\.com).*\\n*"
+      - pattern: "(?i)\\n*Co-Authored-By:.*(?:Claude|@anthropic\\.com).*\\n*"
         description: "Any Co-Authored-By line mentioning Claude or Anthropic"
         replacement: "\n"
 
       # Specific patterns (catch remnants the broad patterns might miss)
-      - pattern: "🤖\\s*Generated with \\[Claude Code\\]\\(https://claude\\.com/claude-code\\)"
+      - pattern: "(?i)🤖\\s*Generated\\s+with\\s+\\[Claude\\s+Code\\]\\(https://claude\\.com/claude-code\\)"
         description: "Claude Code promotional link with emoji"
         replacement: ""
 
-      - pattern: "Co-Authored-By:\\s*Claude\\s*<noreply@anthropic\\.com>"
+      - pattern: "(?i)Co-Authored-By:\\s*Claude\\s*<noreply@anthropic\\.com>"
         description: "Claude Code co-author attribution line"
         replacement: ""
 
-      - pattern: "Generated with Claude Code"
+      - pattern: "(?i)Generated\\s+with\\s+Claude\\s+Code"
         description: "Claude Code generation notice (text-only)"
         replacement: ""
 
-      - pattern: "claude\\.com/claude-code"
+      - pattern: "(?i)claude\\.com/claude-code"
         description: "Claude Code website link"
         replacement: ""
 
-      - pattern: "noreply@anthropic\\.com"
+      - pattern: "(?i)noreply@anthropic\\.com"
         description: "Anthropic noreply email address"
         replacement: ""
 
-      - pattern: "Co-Authored-By:\\s*Claude(?![\\w])"
+      - pattern: "(?i)Co-Authored-By:\\s*Claude(?![\\w])"
         description: "Claude co-author attribution (generic)"
         replacement: ""
 

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1435,3 +1435,56 @@ EOF
         Documented residual: out of scope for #77, not worth gold-plating a fail-open cosmetic
         filter. If this ever changes, it should be a deliberate decision, not an accident."""
         assert self._filter().extract_commit_message('git commit --mess "abbrev"') is None
+
+
+class TestPatternCaseWhitespace:
+    """Issue #85: shipped advertising patterns must match case-insensitively and tolerate
+    variable inter-word whitespace, while user custom_patterns keep case-sensitive semantics.
+    Tests run against the REAL bundled rules (load_filter_config())."""
+
+    @staticmethod
+    def _filter():
+        return CommitMessageFilter(load_filter_config())
+
+    def _blocks(self, body):
+        cmd = f'git commit -m "feat: x\\n\\n{body}"'
+        return bool(self._filter().filter_commit_message(cmd).patterns_removed)
+
+    def test_lowercase_blocked(self):
+        assert self._blocks("generated with claude code")
+
+    def test_mixed_case_blocked(self):
+        assert self._blocks("GeNeRaTeD WiTh ClAuDe CoDe")
+
+    def test_double_spaces_blocked(self):
+        assert self._blocks("Generated  with  Claude  Code")
+
+    def test_tab_separated_blocked(self):
+        assert self._blocks("Generated\twith\tClaude\tCode")
+
+    def test_canonical_still_blocked(self):
+        # No-regression anchor: exact canonical trailer must still be caught.
+        assert self._blocks("Generated with Claude Code")
+
+    def test_canonical_full_trailer_still_blocked(self):
+        body = "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+        assert self._blocks(body)
+
+    def test_lowercase_coauthored_blocked(self):
+        assert self._blocks("co-authored-by: claude <noreply@anthropic.com>")
+
+    def test_clean_message_not_blocked(self):
+        # No false positive: a legitimate message containing the word "generated" elsewhere.
+        cmd = 'git commit -m "feat: regenerated the cache index"'
+        assert not self._filter().filter_commit_message(cmd).patterns_removed
+
+    def test_custom_patterns_remain_case_sensitive(self):
+        # The YAML edit must not flip user custom_patterns to case-insensitive.
+        cfg = {
+            "enabled": True,
+            "rules": {},
+            "custom_patterns": [{"pattern": "SECRET", "description": "c", "replacement": ""}],
+        }
+        filt = CommitMessageFilter(cfg)
+        _cleaned, patterns, _ = filt.clean_message("has secret lowercase")
+        assert not patterns  # lowercase 'secret' must NOT match the case-sensitive custom pattern


### PR DESCRIPTION
Closes #85.

## Problem
The commit-message advertising patterns compiled with `re.DOTALL | re.MULTILINE` but **no `re.IGNORECASE`**, and used literal single spaces between words. So case-folded (`generated with claude code`) and doubled-space (`Generated  with  Claude  Code`) variants bypassed the scannable path (verified live on v0.7.1).

## Fix
Pure `data/commit_filter_rules.yaml` edit — **no code change**:
- Prepend `(?i)` to each advertising pattern (case-insensitive).
- Replace literal inter-word spaces with `\s+` in multi-word phrases (whitespace-tolerant).

Confined to the shipped advertising patterns, so user `custom_patterns` keep their case-sensitive semantics (no global `re.IGNORECASE` in `_compile_patterns`).

## Tests
New `TestPatternCaseWhitespace` (9 tests) against the real bundled config: lowercase / mixed-case / double-space / tab-separated all blocked; canonical trailer still blocked (no-regression anchors); a clean "regenerated" message not blocked (no false positive); custom patterns stay case-sensitive. Full suite green.
