### PR TITLE
fix(commit-filter): scan stdin-heredoc commit messages (#87)

### DIFF
--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -303,7 +303,18 @@ class CommitMessageFilter:
         except Exception as e:
             logger.warning(f"Regex extraction failed: {e}")
 
-        # Both methods failed → fail-open (return None)
+        # Fallback: stdin heredoc feeding `git commit -F-` (issue #87). The bashlex/-m and regex
+        # attempts above don't see it (the body is a redirect, not a -m value), but the bytes are
+        # in the command string, so it is scannable.
+        try:
+            message = self._extract_heredoc_stdin_message(command)
+            if message is not None:
+                logger.debug("Extracted message via stdin-heredoc fallback")
+                return message
+        except Exception as e:  # noqa: BLE001 - fail-open cosmetic filter
+            logger.warning(f"Heredoc stdin extraction failed: {e}")
+
+        # All methods failed → fail-open (return None)
         return None
 
     def classify_message_delivery(self, command: str) -> str:
@@ -351,6 +362,11 @@ class CommitMessageFilter:
         anything else is reuse/editor deferral -> ``none``.
         """
         if self._command_has_file_content_flag(command):
+            # Issue #87: a `-F-`/`--file -` fed by an in-command heredoc has its bytes in argv,
+            # so it is scannable, NOT unscannable. A real file (-F path), piped stdin, or no
+            # heredoc returns None here and stays unscannable.
+            if extracted is not None and self._extract_heredoc_stdin_message(command) is not None:
+                return "scannable"
             return "unscannable"
         if extracted is not None:
             return "scannable"
@@ -383,6 +399,74 @@ class CommitMessageFilter:
             if ch in "mCc":  # argument-taking flag; the rest of the token is its value, not flags
                 return False
         return False
+
+    @staticmethod
+    def _arg_targets_stdin(args: list[str]) -> bool:
+        """True if a -F/--file flag in these post-``commit`` args reads the message from STDIN
+        (target ``-`` or ``/dev/stdin``) rather than a real file — i.e. a heredoc-feedable
+        delivery. Walks short-flag clusters like _short_cluster_has_file_flag: an argument-taking
+        flag (m/C/c) reached before F means the remainder is that flag's value, not a file flag.
+        """
+        stdin_targets = ("-", "/dev/stdin")
+        i = 0
+        while i < len(args):
+            word = args[i]
+            if word == "--":
+                break  # pathspec terminator
+            if word == "--file":
+                return i + 1 < len(args) and args[i + 1] in stdin_targets
+            if word.startswith("--file="):
+                return word[len("--file=") :] in stdin_targets
+            if word.startswith("-") and not word.startswith("--"):
+                rest = word[1:]
+                for j, ch in enumerate(rest):
+                    if ch in "mCc":
+                        break  # argument-taking flag swallows the remainder as its value
+                    if ch == "F":
+                        attached = rest[j + 1 :]
+                        if attached:
+                            return attached in stdin_targets  # -F-, -F/dev/stdin, -aF-
+                        return i + 1 < len(args) and args[i + 1] in stdin_targets  # -F -
+            i += 1
+        return False
+
+    # Cheap, LINEAR (non-backtracking) heredoc-opener counter. Used to bail out of the more
+    # expensive O(n^2)-prone body regex unless there is EXACTLY one heredoc — see
+    # _extract_heredoc_stdin_message. Matches <<EOF / <<'EOF' / <<"EOF" / <<-EOF / << EOF.
+    _HEREDOC_OPENER_RE = re.compile(r"<<-?[ \t]*['\"]?\w+")
+
+    # Heredoc body feeding `git commit -F-` / `--file -`. Matches <<EOF, <<'EOF', <<"EOF",
+    # <<-EOF, << EOF and arbitrary \w+ delimiter names; captures the body up to a line that is
+    # the (optionally tab-indented) delimiter alone. DOTALL so the body spans lines.
+    _HEREDOC_BODY_RE = re.compile(r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?:\n|$)", re.DOTALL)
+
+    def _extract_heredoc_stdin_message(self, command: str) -> Optional[str]:
+        """Commit message of a ``git commit -F-`` / ``--file -`` fed by an in-command heredoc.
+
+        Returns the heredoc body when (a) some ``git … commit`` segment reads its message from
+        stdin (``-F -`` / ``--file -`` / ``/dev/stdin``) AND (b) a heredoc body is present in the
+        command string; otherwise ``None``. This reclassifies the stdin-heredoc form from
+        ``unscannable`` to ``scannable`` (issue #87) — its bytes ARE in argv, unlike ``-F file``
+        (on disk) or ``cat f | git commit -F-`` (in a prior pipe segment), both of which return
+        ``None`` here and stay unscannable. Fail-open: any uncertainty → ``None``.
+
+        bashlex raises on quoted-delimiter heredocs (``<<'EOF'``), so the STDIN gate reuses the
+        tolerant ``_git_commit_arg_lists`` infra while the BODY is taken by regex (uniform across
+        quoted and unquoted forms).
+        """
+        if len(command) > MAX_COMMAND_SIZE:
+            return None  # DoS guard: never run the DOTALL body regex on an oversized command
+        if not any(self._arg_targets_stdin(args) for args in self._git_commit_arg_lists(command)):
+            return None
+        # Only the UNAMBIGUOUS single-heredoc case can be bound to the stdin-fed commit segment.
+        # With 0 or 2+ heredocs, binding by position would guess wrong — leaking an ad behind a
+        # clean leading heredoc, or false-blocking a clean commit whose sibling heredoc contains
+        # the token — so fail open to unscannable instead. The linear opener count also starves
+        # the O(n^2) DOTALL body search of any multi-`<<` adversarial input within MAX_COMMAND_SIZE.
+        if len(self._HEREDOC_OPENER_RE.findall(command)) != 1:
+            return None
+        match = self._HEREDOC_BODY_RE.search(command)
+        return match.group(3) if match else None
 
     # Explanation surfaced when an unscannable commit is warned/blocked. Unscannable always
     # means file/stdin delivery (-F/--file), so a single static message suffices.

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1435,3 +1435,112 @@ EOF
         Documented residual: out of scope for #77, not worth gold-plating a fail-open cosmetic
         filter. If this ever changes, it should be a deliberate decision, not an accident."""
         assert self._filter().extract_commit_message('git commit --mess "abbrev"') is None
+
+
+class TestHeredocStdinExtraction:
+    """Issue #87: a commit message delivered via a stdin heredoc (git commit -F- <<EOF) has its
+    bytes in the command string, so it is SCANNABLE — not unscannable. A real file (-F path), a
+    pipe (cat f | git commit -F-), or interactive stdin (no heredoc) stays unscannable."""
+
+    @staticmethod
+    def _filter(rules=None):
+        return CommitMessageFilter({"enabled": True, "rules": rules or {}})
+
+    @staticmethod
+    def _ad_rules():
+        return {
+            "advertising": {
+                "enabled": True,
+                "patterns": [{"pattern": "Generated with Claude Code", "description": "ad", "replacement": ""}],
+            }
+        }
+
+    def test_unquoted_heredoc_is_scannable(self):
+        cmd = "git commit -F- <<EOF\nfeat: x\nEOF"
+        assert self._filter().classify_message_delivery(cmd) == "scannable"
+
+    def test_quoted_heredoc_is_scannable(self):
+        # bashlex cannot parse <<'EOF'; the regex body-extractor must.
+        cmd = "git commit -F- <<'EOF'\nfeat: x\nEOF"
+        assert self._filter().classify_message_delivery(cmd) == "scannable"
+
+    def test_unquoted_heredoc_advertising_blocked(self):
+        cmd = "git commit -F- <<EOF\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        result = self._filter(self._ad_rules()).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    def test_quoted_heredoc_advertising_blocked(self):
+        cmd = "git commit -F- <<'EOF'\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        assert self._filter(self._ad_rules()).filter_commit_message(cmd).patterns_removed
+
+    def test_clean_heredoc_not_flagged(self):
+        cmd = "git commit -F- <<'EOF'\nfeat: totally clean\nEOF"
+        result = self._filter(self._ad_rules()).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert not result.patterns_removed
+        assert result.unscannable_decision is None
+
+    def test_dash_strip_and_custom_delimiter(self):
+        cmd = "git commit -F- <<-MSG\n\tfeat: x\n\tGenerated with Claude Code\n\tMSG"
+        assert self._filter(self._ad_rules()).filter_commit_message(cmd).patterns_removed
+
+    def test_separate_dash_form(self):
+        cmd = "git commit -F - <<EOF\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        assert self._filter(self._ad_rules()).filter_commit_message(cmd).patterns_removed
+
+    def test_compound_with_heredoc(self):
+        cmd = "git add -A && git commit -F- <<EOF\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        assert self._filter(self._ad_rules()).filter_commit_message(cmd).patterns_removed
+
+    def test_real_file_stays_unscannable(self):
+        assert self._filter().classify_message_delivery("git commit -F /tmp/msg.txt") == "unscannable"
+
+    def test_piped_stdin_stays_unscannable(self):
+        # bytes live in a prior pipe segment, not a heredoc in the command
+        assert self._filter().classify_message_delivery("cat /tmp/ad.txt | git commit -F-") == "unscannable"
+
+    def test_bare_stdin_no_heredoc_unscannable(self):
+        assert self._filter().classify_message_delivery("git commit -F -") == "unscannable"
+
+    def test_inline_m_unaffected(self):
+        assert self._filter().classify_message_delivery('git commit -m "feat: clean"') == "scannable"
+
+    def test_double_quoted_delimiter(self):
+        cmd = 'git commit -F- <<"EOF"\nfeat: x\n\nGenerated with Claude Code\nEOF'
+        assert self._filter(self._ad_rules()).filter_commit_message(cmd).patterns_removed
+
+    def test_space_before_delimiter(self):
+        cmd = "git commit -F- << EOF\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        assert self._filter(self._ad_rules()).filter_commit_message(cmd).patterns_removed
+
+    def test_dev_stdin_target_scannable(self):
+        cmd = "git commit -F /dev/stdin <<EOF\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        result = self._filter(self._ad_rules()).filter_commit_message(cmd)
+        assert result.message_delivery == "scannable"
+        assert result.patterns_removed
+
+    def test_preceding_clean_heredoc_does_not_mask_commit_ad(self):
+        # Two heredocs: clean leading one + the real commit carrying an ad. Must NOT be scanned
+        # as clean-scannable (that would let the ad through) — fall back to unscannable.
+        cmd = "cat <<DATA\nsome clean data\nDATA\ngit commit -F- <<EOF\nfeat: x\n\nGenerated with Claude Code\nEOF"
+        result = self._filter(self._ad_rules()).filter_commit_message(cmd)
+        assert result.message_delivery == "unscannable"
+        assert not result.patterns_removed
+
+    def test_preceding_dirty_heredoc_does_not_block_clean_commit(self):
+        # Two heredocs: a leading file heredoc that contains the token + a CLEAN commit.
+        # Must NOT be blocked — fall back to unscannable.
+        cmd = (
+            "tee notes.txt <<NOTES\nGenerated with Claude Code\nNOTES\n"
+            "git add notes.txt && git commit -F- <<MSG\ndocs: add notes\nMSG"
+        )
+        result = self._filter(self._ad_rules()).filter_commit_message(cmd)
+        assert not result.patterns_removed
+        assert result.message_delivery == "unscannable"
+
+    def test_multiple_heredocs_stay_unscannable(self):
+        # >1 heredoc: binding is ambiguous, so refuse to guess and stay unscannable (also covers
+        # the O(n^2) body-regex ReDoS input shape, which is exactly many `<<` openers).
+        cmd = "git commit -F- <<A\na\nA\ncat <<B\nb\nB"
+        assert self._filter().classify_message_delivery(cmd) == "unscannable"


### PR DESCRIPTION
Closes #87.

## Problem
A commit message delivered via a stdin heredoc (`git commit -F- <<EOF … EOF`) was classified `unscannable` (only warned), even though the heredoc body is physically present in the command string. The bytes ARE in argv — unlike `-F realfile` (on disk) or `cat f | git commit -F-` (a prior pipe segment).

## Fix (`src/schlock/integrations/commit_filter.py`)
- `_arg_targets_stdin` — detects a `-F`/`--file` flag targeting stdin (`-` / `/dev/stdin`), distinguishing it from a real file; mirrors the existing short-flag cluster walk (`-F-`, `-F -`, `-aF-`, `--file=-`, stops at argument-taking `m/C/c`).
- `_extract_heredoc_stdin_message` — when a commit segment reads from stdin **and exactly one heredoc** is present, extract its body via regex (`_HEREDOC_BODY_RE`, handling `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`, `<< EOF`, arbitrary delimiter names — bashlex can't parse quoted-delimiter heredocs). Wired into `extract_commit_message` (fallback) and `_classify_from_extraction` (the `-F-`+heredoc case becomes `scannable`).
- **Single-heredoc only:** with 0 or 2+ heredocs the body can't be reliably bound to the stdin-fed segment, so it fails open to `unscannable` rather than guessing — which would both leak an ad behind a clean leading heredoc and false-block a clean commit with a dirty sibling heredoc. A cheap **linear** opener counter (`_HEREDOC_OPENER_RE`) enforces this and starves the O(n²) DOTALL body regex of any multi-`<<` adversarial input.

**Net:** a clean heredoc commit passes silently; an advertising heredoc commit is blocked on the pattern. `-F realfile`, piped stdin, and bare `-F -` stay `unscannable`.

## Tests
New `TestHeredocStdinExtraction` (18 tests): unquoted/quoted/`<<-`/`<<"EOF"`/`<< EOF`/`/dev/stdin`/separate-dash/compound forms scannable+blocked; clean heredoc passes; real-file / piped / bare-stdin stay unscannable; and the multi-heredoc binding cases (clean-leading mask, dirty-leading false-block, generic >1 → unscannable). Fail-open throughout. Full suite green.
