### PR TITLE
perf(commit-filter): memoize bashlex parse per command (#91)

### DIFF
--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -30,6 +30,8 @@ DO NOT merge these parsers. Different failure semantics require separate code pa
 
 import logging
 import re
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -64,6 +66,12 @@ _ATTACHED_LONG_PREFIX = _LONG_MESSAGE_FLAG + "="  # "--message="
 #   -m<ws>           kept strict with \s+ so existing -m behavior is byte-for-byte unchanged
 #   --message<ws>    or   --message=
 _MSG_FLAG = r"(?:-m\s+|--message(?:\s+|=))"
+
+# Upper bound on memoized bashlex parses per CommitMessageFilter instance (issue #91). The filter
+# is a process-level singleton in the hook; this caps memory while still deduping the repeated
+# parses within a single filter_commit_message call (the actual win). Small: a process rarely sees
+# this many distinct git-commit commands.
+_PARSE_CACHE_MAX = 64
 
 
 @dataclass(frozen=True)
@@ -139,6 +147,11 @@ class CommitMessageFilter:
         """
         self.config = config
         self.enabled = config.get("enabled", True)  # Default: enabled
+
+        # Per-instance memo for bashlex.parse (issue #91). Maps command string -> (ok, value):
+        # (True, parsed_node_list) on success, (False, exception) on parse failure. Bounded LRU.
+        self._parse_cache: OrderedDict[str, tuple[bool, Any]] = OrderedDict()
+        self._parse_lock = threading.Lock()
 
         # Policy for commit messages whose content is NOT in argv (issue #76): file/stdin
         # delivery or unevaluated substitution. "warn" is the safe default — non-destructive
@@ -476,6 +489,51 @@ class CommitMessageFilter:
         "scanning, or remove any unwanted trailer manually."
     )
 
+    def _parse(self, command: str) -> list[Any]:
+        """Memoized ``bashlex.parse`` chokepoint (issue #91).
+
+        Returns a materialized (re-iterable) list of AST nodes. Both call sites
+        (_commit_arg_word_lists, _extract_via_bashlex) route through here so a command is
+        parsed once per filter call. Caches BOTH outcomes keyed by exact command string:
+        success -> (True, nodes), failure -> (False, exc). On a failure hit the original
+        exception is re-raised, so callers' fail-open handling is byte-for-byte unchanged.
+
+        Callers MUST size-guard (MAX_COMMAND_SIZE) before calling, exactly as before — this
+        method intentionally has no DoS guard so the oversized short-circuit never reaches it.
+        """
+        with self._parse_lock:
+            hit = self._parse_cache.get(command)
+            if hit is not None:
+                self._parse_cache.move_to_end(command)
+                ok, val = hit
+                if ok:
+                    return val
+                # Reset the traceback before each re-raise: re-raising one stored instance would
+                # otherwise accumulate frames on every cache hit (the cache outlives a single call).
+                # Type/message/args are preserved, so callers' typed except handling is unchanged.
+                raise val.with_traceback(None)
+        # Parse OUTSIDE the lock: never hold the lock across a ~300ms parse. A concurrent
+        # double-miss on the same command just parses twice harmlessly (idempotent, last write wins).
+        try:
+            parsed = list(bashlex.parse(command))
+        except Exception as exc:  # noqa: BLE001 - memoize the failure, then re-raise verbatim
+            with self._parse_lock:
+                self._store(command, (False, exc))
+            raise
+        with self._parse_lock:
+            self._store(command, (True, parsed))
+        return parsed
+
+    def _store(self, command: str, value: tuple[bool, Any]) -> None:
+        """Insert into the parse cache with LRU eviction. Caller holds self._parse_lock."""
+        if command in self._parse_cache:
+            self._parse_cache.move_to_end(command)
+            self._parse_cache[command] = value
+            return
+        if len(self._parse_cache) >= _PARSE_CACHE_MAX:
+            self._parse_cache.popitem(last=False)
+        self._parse_cache[command] = value
+
     def _commit_arg_word_lists(self, command: str) -> list[list[str]]:
         """For each ``git … commit`` invocation, the argument words FOLLOWING ``commit`` (the
         global options and the subcommand itself stripped). Tolerates global options between
@@ -499,7 +557,7 @@ class CommitMessageFilter:
                 for item in child if isinstance(child, list) else [child]:
                     visit(item)
 
-        for part in bashlex.parse(command):
+        for part in self._parse(command):
             visit(part)
         return results
 
@@ -537,7 +595,7 @@ class CommitMessageFilter:
             We use position info to extract the RAW message from the original
             command, then handle `\\n` → newline conversion ourselves.
         """
-        parts = bashlex.parse(command)
+        parts = self._parse(command)
         messages: list[str] = []
 
         def extract_msg_from_node(msg_node: Any) -> str:

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1673,3 +1673,23 @@ class TestParseMemoization:
         # Fail-open: the regex fallback handles extraction; the command is not broken.
         assert result.error is None
         assert result.cleaned_command  # non-empty, command preserved/handled
+
+    def test_repeated_identical_command_cached_across_calls(self):
+        """The per-instance memo persists across calls: a repeated identical command re-parses 0 times."""
+        import bashlex  # noqa: PLC0415
+
+        cmd = "git commit " + " ".join(["-a"] * 10)
+        filt = self._filter()
+        filt.filter_commit_message(cmd)  # warm the cache (parses once)
+        with patch("schlock.integrations.commit_filter.bashlex.parse", wraps=bashlex.parse) as spy:
+            filt.filter_commit_message(cmd)  # second identical call: fully served from cache
+        assert spy.call_count == 0, f"expected 0 parses on repeat, got {spy.call_count}"
+
+    def test_parse_cache_is_bounded_by_max(self):
+        """The parse cache never exceeds _PARSE_CACHE_MAX entries (bounded memory / LRU eviction)."""
+        from schlock.integrations.commit_filter import _PARSE_CACHE_MAX  # noqa: PLC0415
+
+        filt = self._filter()
+        for i in range(_PARSE_CACHE_MAX + 50):
+            filt._parse(f"git commit -m msg{i}")  # each distinct command is a distinct cache entry
+        assert len(filt._parse_cache) == _PARSE_CACHE_MAX

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1597,3 +1597,79 @@ class TestPatternCaseWhitespace:
         filt = CommitMessageFilter(cfg)
         _cleaned, patterns, _ = filt.clean_message("has secret lowercase")
         assert not patterns  # lowercase 'secret' must NOT match the case-sensitive custom pattern
+
+
+class TestParseMemoization:
+    """#91 — bashlex.parse must run at most once per command per filter call."""
+
+    def _filter(self):
+        # Minimal real filter: advertising category enabled so the scannable path is exercised.
+        return CommitMessageFilter(
+            {
+                "enabled": True,
+                "rules": {
+                    "advertising": {
+                        "enabled": True,
+                        "patterns": [
+                            {
+                                "pattern": r"\n*Generated with .*",
+                                "description": "ad",
+                                "replacement": "",
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+
+    def test_filter_parses_once_no_heredoc(self):
+        """The #91 repro: `git commit -a -a -a ...` (no message, no heredoc) parsed once."""
+        import bashlex  # noqa: PLC0415
+
+        cmd = "git commit " + " ".join(["-a"] * 50)
+        filt = self._filter()
+        with patch("schlock.integrations.commit_filter.bashlex.parse", wraps=bashlex.parse) as spy:
+            filt.filter_commit_message(cmd)
+        assert spy.call_count == 1, f"expected 1 parse, got {spy.call_count}"
+
+    def test_scannable_message_parses_once_and_result_unchanged(self):
+        """A scannable `-m` commit: parsed once AND the cleaned result matches a fresh run."""
+        import bashlex  # noqa: PLC0415
+
+        cmd = 'git commit -m "Add feature\\n\\nGenerated with Claude Code"'
+
+        baseline = self._filter().filter_commit_message(cmd)  # fresh instance, no spy
+
+        filt = self._filter()
+        with patch("schlock.integrations.commit_filter.bashlex.parse", wraps=bashlex.parse) as spy:
+            result = filt.filter_commit_message(cmd)
+
+        assert spy.call_count == 1, f"expected 1 parse, got {spy.call_count}"
+        assert result.was_modified is True
+        assert result.cleaned_message == baseline.cleaned_message
+        assert result.message_delivery == baseline.message_delivery == "scannable"
+
+    def test_classify_message_delivery_parses_once(self):
+        """classify_message_delivery is a public entry point; it too must parse once."""
+        import bashlex  # noqa: PLC0415
+
+        cmd = "git commit " + " ".join(["-a"] * 50)
+        filt = self._filter()
+        with patch("schlock.integrations.commit_filter.bashlex.parse", wraps=bashlex.parse) as spy:
+            filt.classify_message_delivery(cmd)
+        assert spy.call_count == 1, f"expected 1 parse, got {spy.call_count}"
+
+    def test_parse_failure_memoized_once_and_fails_open(self):
+        """A quoted-heredoc commit makes bashlex raise; the raise is cached (called once),
+        and filtering still fails open (returns the original command unmodified)."""
+        import bashlex  # noqa: PLC0415
+
+        # bashlex cannot parse <<'EOF' (quoted delimiter) -> every parse attempt raises.
+        cmd = "git commit -m \"$(cat <<'EOF'\nhello\nEOF\n)\""
+        filt = self._filter()
+        with patch("schlock.integrations.commit_filter.bashlex.parse", wraps=bashlex.parse) as spy:
+            result = filt.filter_commit_message(cmd)
+        assert spy.call_count == 1, f"expected 1 parse, got {spy.call_count}"
+        # Fail-open: the regex fallback handles extraction; the command is not broken.
+        assert result.error is None
+        assert result.cleaned_command  # non-empty, command preserved/handled


### PR DESCRIPTION
Closes #91.

## Summary
Routes both `bashlex.parse` call sites in `CommitMessageFilter` through a single memoizing `_parse()` chokepoint backed by a bounded per-instance LRU (`OrderedDict`, max 64, guarded by a lock). A `git … commit` command is now parsed **once** per `filter_commit_message` call instead of up to ~4×, removing the ~1.2 s stall on large commands — a mild DoS, since the always-on PreToolUse hook runs on every Bash call with no wall-clock timeout.

Parse **failures** are memoized too (and re-raised with the traceback reset, so a re-raised stored instance can't accumulate frames across cache hits). Exception **type/args are preserved**, so `extract_commit_message`'s typed `except` ladder still routes correctly and the module's **fail-open** contract is byte-for-byte unchanged.

## Changes
- `_parse()` chokepoint + `_store()` bounded-LRU helper in `src/schlock/integrations/commit_filter.py`; both former `bashlex.parse(command)` sites (`_commit_arg_word_lists`, `_extract_via_bashlex`) rerouted.
- Self-contained — no new `integrations → core` coupling.
- No public API change.

## Test plan
- [x] `bashlex.parse` invoked once per command per call — spy tests (`wraps=bashlex.parse`) for the no-heredoc repro, scannable `-m`, `classify_message_delivery`, and the parse-failure path.
- [x] Cross-call cache reuse (0 re-parses on a repeated command) and LRU bound (≤ 64) covered.
- [x] Fail-open preserved (quoted-heredoc still falls back to regex); oversized DoS guard still short-circuits before `_parse`.
- [x] Full `tests/test_commit_filter.py` green (184 passed); `ruff check` + `ruff format --check` clean.
