### PR TITLE
fix(ci): make osv-scanner download resilient to release-CDN failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,23 +67,17 @@ jobs:
     - name: pip-audit
       run: uv export --no-hashes | uvx pip-audit -r /dev/stdin --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available (transitive dev dep via pytest)
 
-    # Advisory scan: a transient GitHub release-CDN failure must not fail the job, but the
-    # skip must be conspicuous. continue-on-error surfaces a soft-failure (orange) in the UI;
-    # the ::error:: annotation states the scan was skipped. The scan runs only on success.
-    - name: Download osv-scanner
-      id: osv_download
-      continue-on-error: true
-      run: |
-        if ! curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
-             https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o osv-scanner; then
-          echo "::error::osv-scanner download failed (GitHub release CDN); advisory OSV scan SKIPPED this run"
-          exit 1
-        fi
-        chmod +x osv-scanner
-
+    # Advisory OSV scan via the official pinned Docker action (runs ghcr.io image, no manual
+    # binary download / no moving-target latest/ URL). continue-on-error keeps it non-blocking:
+    # a finding or a GHCR/registry hiccup shows as a visible soft-failure, never a release blocker.
+    # Pinned by commit SHA per this workflow's convention; Dependabot (github-actions ecosystem)
+    # bumps the SHA + version comment automatically.
     - name: osv-scanner
-      if: steps.osv_download.outcome == 'success'
-      run: ./osv-scanner --lockfile=uv.lock || true
+      continue-on-error: true
+      uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+      with:
+        scan-args: |-
+          --lockfile=uv.lock
 
     - name: semgrep
       run: uvx semgrep scan --config p/security-audit --config p/python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,9 @@ jobs:
           --lockfile=uv.lock
 
     - name: semgrep
-      run: uvx semgrep scan --config p/security-audit --config p/python
+      # Pinned for reproducible runs. Bump manually — Dependabot can't see versions
+      # embedded in a uvx run-string (unlike the SHA-pinned `uses:` actions above).
+      run: uvx semgrep@1.165.0 scan --config p/security-audit --config p/python
 
     - name: gitleaks
       uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,13 +67,23 @@ jobs:
     - name: pip-audit
       run: uv export --no-hashes | uvx pip-audit -r /dev/stdin --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available (transitive dev dep via pytest)
 
-    - name: osv-scanner
+    # Advisory scan: a transient GitHub release-CDN failure must not fail the job, but the
+    # skip must be conspicuous. continue-on-error surfaces a soft-failure (orange) in the UI;
+    # the ::error:: annotation states the scan was skipped. The scan runs only on success.
+    - name: Download osv-scanner
+      id: osv_download
+      continue-on-error: true
       run: |
-        curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
-          https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o osv-scanner \
-          || { echo "::warning::osv-scanner download failed after retries (e.g. GitHub release CDN 504); skipping advisory scan"; exit 0; }
+        if ! curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
+             https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o osv-scanner; then
+          echo "::error::osv-scanner download failed (GitHub release CDN); advisory OSV scan SKIPPED this run"
+          exit 1
+        fi
         chmod +x osv-scanner
-        ./osv-scanner --lockfile=uv.lock || true
+
+    - name: osv-scanner
+      if: steps.osv_download.outcome == 'success'
+      run: ./osv-scanner --lockfile=uv.lock || true
 
     - name: semgrep
       run: uvx semgrep scan --config p/security-audit --config p/python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,9 @@ jobs:
 
     - name: osv-scanner
       run: |
-        curl -sSfL https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o osv-scanner
+        curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
+          https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o osv-scanner \
+          || { echo "::warning::osv-scanner download failed after retries (e.g. GitHub release CDN 504); skipping advisory scan"; exit 0; }
         chmod +x osv-scanner
         ./osv-scanner --lockfile=uv.lock || true
 


### PR DESCRIPTION
## Problem

The `osv-scanner` step in the `security` job runs an **advisory** scan (`./osv-scanner … || true` — it never fails the build by design). But the step's binary **download was unguarded**:

```yaml
curl -sSfL https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o osv-scanner
```

`-f` makes curl exit non-zero on any HTTP error, with no retry and using the flaky `releases/latest/download` redirect. When GitHub's release CDN returned **`504 Gateway Timeout`**, the download failed → the whole `security` job failed → it **blocked the 0.7.4 release PR (#102)**. A re-run minutes later hit the identical 504, so this was a sustained GitHub-infra incident, not a one-off. The asset itself (`osv-scanner_linux_amd64`, release v2.3.8) is fine.

Net inconsistency: an advisory tool that can't fail the build was nonetheless blocking releases on transient network errors.

## Fix

```yaml
curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
  https://.../osv-scanner_linux_amd64 -o osv-scanner \
  || { echo "::warning::osv-scanner download failed after retries (e.g. GitHub release CDN 504); skipping advisory scan"; exit 0; }
```

- `--retry-all-errors` is required — `--retry` alone does **not** retry HTTP `5xx` responses (curl treats them as "answered").
- On persistent failure, log a `::warning::` and `exit 0`, mirroring the scan's existing advisory intent. A real outage or moved asset stays visible in the Actions log rather than being silently swallowed.

## Validation

- YAML parses; `bash -e` control flow verified locally: download-fail → warn + skip scan + `exit 0` (job stays green); download-ok → proceeds to scan.
- This PR's own `security` job is a live test: if it passes while GitHub's CDN is still 504-ing, the fix works.

After merge, release-please rebases #102 onto `main` and re-runs with this workflow, unblocking the 0.7.4 release.
