### PR TITLE
fix(parser): parse AND-OR lists inside $() to stop fail-closed over-blocks (#96)

### DIFF
--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -75,7 +75,7 @@ def _apply_andor_substitution_correction() -> None:
         action, goto, productions = yp.action, yp.goto, yp.productions
         prod_index = {(p.name, tuple(p.prod)): i for i, p in enumerate(productions)}
 
-        def continuation_state(op: str, *, via_newline_list: bool) -> int | None:
+        def continuation_state(op: str, *, via_newline_list: bool) -> Optional[int]:
             """State reached after shifting ``op`` from the initial ``simple_list1`` state."""
             shifted = action[goto[0]["simple_list1"]].get(op)
             if shifted is None or shifted < 0:  # must be a shift (positive state)

--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -89,15 +89,24 @@ def _apply_andor_substitution_correction() -> None:
             return table.get("simple_list1")
 
         patched: list[int] = []
+        missed = False
         for op, rhs, via_nl in _ANDOR_CORRECTION_SPECS:
             state = continuation_state(op, via_newline_list=via_nl)
             prod = prod_index.get(("simple_list1", rhs))
-            if state is None or prod is None or action[state].get("RIGHT_PAREN") is not None:
-                continue  # absent state/production, or never clobber an existing action
+            if state is None or prod is None:
+                # Could not derive this correction — the table layout may have drifted.
+                missed = True
+                continue
+            if action[state].get("RIGHT_PAREN") is not None:
+                continue  # already supported/applied — natively fine, never clobber it
             action[state]["RIGHT_PAREN"] = -prod
             patched.append(state)
 
-        if patched and not _andor_correction_self_check():
+        # Run the self-check whenever we changed the tables OR a spec failed to derive (drift
+        # signal). Only skip it when every spec was already natively supported (nothing patched,
+        # nothing missed) — there is then nothing to verify. A bare derivation miss must still
+        # warn: a silent degrade to fail-closed over-block is a silent failure.
+        if (patched or missed) and not _andor_correction_self_check():
             for state in patched:
                 action[state].pop("RIGHT_PAREN", None)
             logger.warning(

--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -17,6 +17,99 @@ from schlock.exceptions import ParseError
 
 logger = logging.getLogger(__name__)
 
+
+# Each AND-OR list operator and the `simple_list1` production its `$( … )` close should reduce
+# through (discovered by table-walk, never by hardcoded index). The 4-symbol AND_AND/OR_OR rules
+# need an extra `newline_list` hop vs the 3-symbol AMPERSAND rule.
+_ANDOR_CORRECTION_SPECS = (
+    ("AMPERSAND", ("simple_list1", "AMPERSAND", "simple_list1"), False),
+    ("AND_AND", ("simple_list1", "AND_AND", "newline_list", "simple_list1"), True),
+    ("OR_OR", ("simple_list1", "OR_OR", "newline_list", "simple_list1"), True),
+)
+
+
+def _parse_succeeds(src: str) -> bool:
+    """True if vendored bashlex parses ``src`` without raising (used by the correction self-check)."""
+    try:
+        bashlex.parse(src)
+        return True
+    except Exception:  # noqa: BLE001 - any failure means "did not parse", which is all we need
+        return False
+
+
+def _andor_correction_self_check() -> bool:
+    """Previously-failing AND-OR forms must now parse AND malformed bash must still be rejected."""
+    must_parse = ("echo $(a && b)", "echo $(a || b)", "echo $(a & b)")
+    must_reject = ("echo $(a &&)", "echo $(&& a)", "echo $(a ||)", "echo $(a && && b)")
+    if not all(_parse_succeeds(s) for s in must_parse):
+        return False
+    return not any(_parse_succeeds(s) for s in must_reject)
+
+
+def _apply_andor_substitution_correction() -> None:
+    """Teach bashlex to parse AND-OR lists (``&&``/``||``/``&``) inside ``$( … )``.
+
+    bashlex 0.18 only accepts ``;``-separated lists inside a command substitution: an AND-OR
+    operator there raises ``ParsingError``. Because schlock's safety validator is fail-closed,
+    that turns legitimate commands like ``X=$(cd "$(git rev-parse --git-dir)" && pwd)`` into a
+    hard block. Upstream (idank/bashlex#54) is unfixed and 0.18 is the latest release, so we
+    correct the parser ourselves.
+
+    Root cause: bashlex's own import-time hack ``get_correction_rightparen_states`` adds a
+    ``RIGHT_PAREN`` reduce action only to the SEMICOLON continuation state. The sibling AMPERSAND
+    / AND_AND / OR_OR continuation states have no ``RIGHT_PAREN`` action, so the closing ``)`` of
+    the substitution lands on an error cell. We mirror bashlex's technique and fill those cells.
+
+    Safety: an LALR parse never visits an error (absent) cell, so adding an action to a cell that
+    is currently absent cannot change the parse of any input that already parsed — only the
+    inputs that previously hit ``p_error`` are affected. We therefore patch a cell ONLY when it is
+    absent, and reduce via each operator's own ``simple_list1`` production so the resulting AST
+    matches a top-level ``a && b`` list.
+
+    Degrades gracefully: if the table layout ever drifts (new bashlex / arch) and the walk derives
+    a wrong cell, a self-check reverts every patched cell and logs a warning, leaving the
+    fail-closed status quo (over-block) rather than risking a structurally wrong AST.
+    """
+    try:
+        yp = bashlex.parser.yaccparser
+        action, goto, productions = yp.action, yp.goto, yp.productions
+        prod_index = {(p.name, tuple(p.prod)): i for i, p in enumerate(productions)}
+
+        def continuation_state(op: str, *, via_newline_list: bool) -> int | None:
+            """State reached after shifting ``op`` from the initial ``simple_list1`` state."""
+            shifted = action[goto[0]["simple_list1"]].get(op)
+            if shifted is None or shifted < 0:  # must be a shift (positive state)
+                return None
+            table = goto[shifted]
+            if via_newline_list:
+                nl = table.get("newline_list")
+                if nl is None:
+                    return None
+                table = goto[nl]
+            return table.get("simple_list1")
+
+        patched: list[int] = []
+        for op, rhs, via_nl in _ANDOR_CORRECTION_SPECS:
+            state = continuation_state(op, via_newline_list=via_nl)
+            prod = prod_index.get(("simple_list1", rhs))
+            if state is None or prod is None or action[state].get("RIGHT_PAREN") is not None:
+                continue  # absent state/production, or never clobber an existing action
+            action[state]["RIGHT_PAREN"] = -prod
+            patched.append(state)
+
+        if patched and not _andor_correction_self_check():
+            for state in patched:
+                action[state].pop("RIGHT_PAREN", None)
+            logger.warning(
+                "bashlex AND-OR substitution correction failed self-check; reverted "
+                "(legitimate $(a && b) substitutions will be conservatively blocked)"
+            )
+    except Exception:  # noqa: BLE001 - correction is best-effort; never break import
+        logger.warning("bashlex AND-OR substitution correction could not be applied", exc_info=True)
+
+
+_apply_andor_substitution_correction()
+
 # Interpreters that EXECUTE their standard input as a program when given no program source.
 # Used to detect top-level pipe-to-shell (cmd | bash). DELIBERATELY EXCLUDES xargs/env:
 # those run a *named* command, not stdin-as-program, and are covered by the download->shell

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -88,6 +88,10 @@ SAFE_SUBSTITUTION_COMMANDS: frozenset[str] = frozenset(
         "cksum",
         # Git (read-only operations - write ops would fail in substitution anyway)
         "git",
+        # Directory change (subshell-pure: only affects cwd inside the $() subshell, no exec).
+        # Safe to whitelist now that $(cd … && …) parses; without it the canonical repro
+        # X=$(cd "$(git rev-parse --git-dir)" && pwd) still hard-blocks on unknown "cd".
+        "cd",
         # Path manipulation (pure functions)
         "basename",
         "dirname",
@@ -544,11 +548,23 @@ class SubstitutionNode:
     """Represents a command or process substitution in the AST."""
 
     substitution_type: SubstitutionType
-    inner_command: str  # The command text inside the substitution
+    inner_command: str | None  # The command text inside the substitution (None if unrenderable, e.g. compound list segment)
     base_command: str | None  # First word of inner command (e.g., "op" from "op read ...")
     ast_node: Any  # The bashlex AST node
     nested_substitutions: list[SubstitutionNode] = field(default_factory=list)
     depth: int = 0  # Nesting depth
+
+
+class _ListSegment:
+    """Minimal stand-in that exposes one segment of a command list as a substitution's
+    ``.command``, so the extraction/validation helpers (which read ``node.command``) can be reused
+    to validate each `&&`/`||`/`;`/`&` segment independently.
+    """
+
+    __slots__ = ("command",)
+
+    def __init__(self, command: Any) -> None:
+        self.command = command
 
 
 @dataclass
@@ -645,7 +661,14 @@ class SubstitutionValidator:
             SubstitutionNode or None if extraction fails
         """
         inner_command = self._extract_inner_command_text(node)
-        if not inner_command:
+        # A command list ($(a && b), $(a; b)) is validated per-segment from its AST, so it must
+        # survive even when text rendering is partial (e.g. a compound segment renders to None).
+        # Dropping it here would silently skip validation -> fail OPEN. Per-segment logic blocks
+        # the unrenderable segment instead. Non-list substitutions with no extractable command
+        # stay dropped (genuinely unparseable).
+        cmd_node = getattr(node, "command", None)
+        is_list = getattr(cmd_node, "kind", None) == "list"
+        if not inner_command and not is_list:
             return None
 
         base_command = self._extract_base_command(node)
@@ -698,20 +721,24 @@ class SubstitutionValidator:
                             parts_text.append("|")
             return " ".join(parts_text) if parts_text else None
 
-        # Handle command list: $(cmd1; cmd2) or $(cmd1 && cmd2)
+        # Handle command list: $(cmd1; cmd2), $(cmd1 && cmd2), $(cmd1 | cmd2 || cmd3), ...
+        # This text feeds the Layer-4 YAML rule match and the audit log, so it must render EVERY
+        # segment faithfully. A segment that cannot be rendered returns None (fail closed) rather
+        # than a truncated string that would hide a dropped pipeline/compound from the rule engine.
         if hasattr(cmd_node, "kind") and cmd_node.kind == "list":
-            # For command lists, extract all parts
             parts_text = []
             if hasattr(cmd_node, "parts"):
                 for part in cmd_node.parts:
-                    if hasattr(part, "kind") and part.kind == "command":
-                        if hasattr(part, "parts"):
-                            cmd_words = [p.word for p in part.parts if hasattr(p, "word")]
-                            if cmd_words:
-                                parts_text.append(" ".join(cmd_words))
-                    elif hasattr(part, "kind") and part.kind == "operator":
-                        if hasattr(part, "op"):
-                            parts_text.append(part.op)
+                    kind = getattr(part, "kind", None)
+                    if kind == "operator":
+                        if not hasattr(part, "op"):
+                            return None
+                        parts_text.append(part.op)
+                        continue
+                    rendered = self._render_segment_text(part)
+                    if rendered is None:
+                        return None  # unrenderable segment -> fail closed
+                    parts_text.append(rendered)
             return " ".join(parts_text) if parts_text else None
 
         # Handle simple command: try to get from parts
@@ -734,7 +761,58 @@ class SubstitutionValidator:
 
         return None
 
-    def _extract_base_command(self, node: Any) -> str | None:  # noqa: PLR0911
+    def _segment_base_command(self, node: Any) -> str | None:
+        """First word of a list segment (a `command`, or the first command of a `pipeline`).
+
+        Returns None for a compound segment or anything without a leading word, which the caller
+        treats as fail-closed (base_command=None -> blocked).
+        """
+        kind = getattr(node, "kind", None)
+        if kind == "command":
+            parts = getattr(node, "parts", None)
+            if parts and hasattr(parts[0], "word"):
+                return parts[0].word
+            return None
+        if kind == "pipeline":
+            for part in getattr(node, "parts", []):
+                if getattr(part, "kind", None) == "command":
+                    parts = getattr(part, "parts", None)
+                    if parts and hasattr(parts[0], "word"):
+                        return parts[0].word
+                    return None
+            return None
+        return None
+
+    def _render_segment_text(self, node: Any) -> str | None:
+        """Render one list segment (command or pipeline) to faithful command text.
+
+        Returns None for anything that cannot be rendered verbatim (compound `{ … }`/`( … )`,
+        a pipeline containing a reserved word like `!`, or an empty command). Callers treat None
+        as fail-closed: the segment is still validated structurally via its AST node, but it never
+        contributes a truncated string to the rule engine or audit log. Redirections are dropped
+        from the text (they are detected structurally), matching the simple-command rendering.
+        """
+        kind = getattr(node, "kind", None)
+        if kind == "command":
+            words = [p.word for p in getattr(node, "parts", []) if hasattr(p, "word")]
+            return " ".join(words) if words else None
+        if kind == "pipeline":
+            rendered: list[str] = []
+            for part in getattr(node, "parts", []):
+                part_kind = getattr(part, "kind", None)
+                if part_kind == "pipe":
+                    rendered.append("|")
+                elif part_kind == "command":
+                    words = [p.word for p in getattr(part, "parts", []) if hasattr(p, "word")]
+                    if not words:
+                        return None
+                    rendered.append(" ".join(words))
+                else:
+                    return None  # reserved word / unexpected node -> fail closed
+            return " ".join(rendered) if rendered else None
+        return None  # compound or unknown segment -> cannot render faithfully
+
+    def _extract_base_command(self, node: Any) -> str | None:  # noqa: PLR0911, PLR0912
         """Extract the base command (first word) from a substitution.
 
         Args:
@@ -748,6 +826,16 @@ class SubstitutionValidator:
 
         cmd_node = node.command
         if not cmd_node:
+            return None
+
+        # Handle command list: $(cmd1 && cmd2) / $(cmd1; cmd2) -> first segment's base command.
+        # Without this the list base_command is None and validate_substitution falls through to
+        # the "Cannot determine command in substitution" hard block.
+        if hasattr(cmd_node, "kind") and cmd_node.kind == "list":
+            for part in getattr(cmd_node, "parts", []):
+                if getattr(part, "kind", None) == "operator":
+                    continue
+                return self._segment_base_command(part)
             return None
 
         # Handle pipeline - get first command in pipeline
@@ -1011,6 +1099,77 @@ class SubstitutionValidator:
 
         return None
 
+    def _validate_list_segments(self, sub_node: SubstitutionNode, cmd_node: Any, depth: int) -> SubstitutionValidationResult:
+        """Validate a command-list substitution segment-by-segment.
+
+        Each non-operator segment ($(a && b) -> [a, b]) is wrapped as its own substitution and
+        run through the full ``validate_substitution`` pipeline at the SAME depth (decomposition,
+        not nesting). The list is allowed only if every segment is allowed; the combined risk is
+        the max over segments and it is whitelisted only if every segment is. The whole rendered
+        text is then re-checked against the YAML rules to catch cross-segment patterns.
+
+        Fail-closed: a segment we cannot turn into a substitution node (e.g. a compound
+        ``{ … }``/``( … )``/``if`` segment) blocks the whole list.
+        """
+        from .rules import RiskLevel  # noqa: PLC0415
+
+        risk_order = [RiskLevel.SAFE, RiskLevel.LOW, RiskLevel.MEDIUM, RiskLevel.HIGH, RiskLevel.BLOCKED]
+        segments = [p for p in getattr(cmd_node, "parts", []) if getattr(p, "kind", None) != "operator"]
+        if not segments:
+            return SubstitutionValidationResult(
+                allowed=False,
+                risk_level=RiskLevel.BLOCKED,
+                message="Empty command list in substitution",
+            )
+
+        inner_results: list[SubstitutionValidationResult] = []
+        max_risk = RiskLevel.SAFE
+        all_whitelisted = True
+
+        for segment in segments:
+            child = self._create_substitution_node(_ListSegment(segment), sub_node.substitution_type, depth)
+            if child is None:
+                # Unrenderable segment (compound command, empty, etc.) -> block fail-closed.
+                return SubstitutionValidationResult(
+                    allowed=False,
+                    risk_level=RiskLevel.BLOCKED,
+                    message="Cannot determine command in substitution segment",
+                    inner_results=inner_results,
+                )
+            result = self.validate_substitution(child, depth)
+            inner_results.append(result)
+            if not result.allowed:
+                return SubstitutionValidationResult(
+                    allowed=False,
+                    risk_level=result.risk_level,
+                    message=result.message,
+                    inner_results=inner_results,
+                )
+            if risk_order.index(result.risk_level) > risk_order.index(max_risk):
+                max_risk = result.risk_level
+            all_whitelisted = all_whitelisted and result.whitelisted
+
+        # Cross-segment defense-in-depth: re-match the full rendered text against the rules.
+        if sub_node.inner_command and self.rule_engine is not None:
+            rule_match = self.rule_engine.match_command(sub_node.inner_command)
+            if rule_match and rule_match.matched:
+                amplified_risk = self._amplify_risk(rule_match.risk_level)
+                if amplified_risk in (RiskLevel.BLOCKED, RiskLevel.HIGH):
+                    return SubstitutionValidationResult(
+                        allowed=False,
+                        risk_level=RiskLevel.BLOCKED,
+                        message=f"Inner command blocked: {rule_match.message}",
+                        inner_results=inner_results,
+                    )
+
+        return SubstitutionValidationResult(
+            allowed=True,
+            risk_level=max_risk,
+            message="Command list segments validated",
+            whitelisted=all_whitelisted,
+            inner_results=inner_results,
+        )
+
     def validate_substitution(  # noqa: PLR0911, PLR0912
         self, sub_node: SubstitutionNode, depth: int = 0
     ) -> SubstitutionValidationResult:
@@ -1034,6 +1193,14 @@ class SubstitutionValidator:
                 message=f"Substitution nesting depth exceeded (max {MAX_SUBSTITUTION_DEPTH})",
                 depth_exceeded=True,
             )
+
+        # Command list: $(a && b), $(a; b), $(a & b), $(a || b). Validate each segment
+        # independently and combine. Done BEFORE the whitelist fast path because a list's
+        # base_command is just its FIRST segment's command — fast-pathing the whole chain on that
+        # would skip validation of later segments (e.g. $(date; rm -rf /)).
+        cmd_node = getattr(sub_node.ast_node, "command", None)
+        if getattr(cmd_node, "kind", None) == "list":
+            return self._validate_list_segments(sub_node, cmd_node, depth)
 
         # Layer 1: Whitelist check (fast path) - WITH STRUCTURAL VALIDATION
         if self.is_whitelisted(sub_node.base_command):

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 # Maximum recursion depth for nested substitution validation
 MAX_SUBSTITUTION_DEPTH = 10
 
+# Operators bashlex emits in a command-list node's parts. A well-formed list strictly alternates
+# segment/operator and ends on a segment; anything else is a malformed AST -> fail closed.
+_LIST_OPERATORS: frozenset[str] = frozenset({"&&", "||", ";", "&"})
+
 # Commands that are ALWAYS safe inside substitution
 # These are read-only, pure, or security-critical tools that don't modify state
 SAFE_SUBSTITUTION_COMMANDS: frozenset[str] = frozenset(
@@ -1099,6 +1103,22 @@ class SubstitutionValidator:
 
         return None
 
+    def _is_valid_list_topology(self, parts: list[Any]) -> bool:
+        """True if ``parts`` is a well-formed bashlex command list: strictly alternating
+        segment / operator, odd length >= 1, ending on a segment, with every operator slot a
+        recognized list operator. Anything else is a malformed AST and the caller fails closed.
+        """
+        if not parts or len(parts) % 2 == 0:
+            return False
+        for index, part in enumerate(parts):
+            is_operator = getattr(part, "kind", None) == "operator"
+            if index % 2 == 0:
+                if is_operator:
+                    return False  # segment slot occupied by an operator
+            elif not is_operator or getattr(part, "op", None) not in _LIST_OPERATORS:
+                return False  # operator slot missing a recognized op
+        return True
+
     def _validate_list_segments(self, sub_node: SubstitutionNode, cmd_node: Any, depth: int) -> SubstitutionValidationResult:
         """Validate a command-list substitution segment-by-segment.
 
@@ -1114,7 +1134,18 @@ class SubstitutionValidator:
         from .rules import RiskLevel  # noqa: PLC0415
 
         risk_order = [RiskLevel.SAFE, RiskLevel.LOW, RiskLevel.MEDIUM, RiskLevel.HIGH, RiskLevel.BLOCKED]
-        segments = [p for p in getattr(cmd_node, "parts", []) if getattr(p, "kind", None) != "operator"]
+        parts = list(getattr(cmd_node, "parts", []))
+        # Validate the raw topology BEFORE dropping operators: a well-formed list strictly
+        # alternates segment/operator and ends on a segment. A malformed shape (e.g. a trailing or
+        # op-less operator node) must block rather than silently validate the surviving segments.
+        if not self._is_valid_list_topology(parts):
+            return SubstitutionValidationResult(
+                allowed=False,
+                risk_level=RiskLevel.BLOCKED,
+                message="Malformed list topology in substitution",
+            )
+
+        segments = [p for p in parts if getattr(p, "kind", None) != "operator"]
         if not segments:
             return SubstitutionValidationResult(
                 allowed=False,

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -1145,13 +1145,9 @@ class SubstitutionValidator:
                 message="Malformed list topology in substitution",
             )
 
+        # A valid topology guarantees at least one segment (index 0 is always a segment slot),
+        # so there is no separate empty-list branch.
         segments = [p for p in parts if getattr(p, "kind", None) != "operator"]
-        if not segments:
-            return SubstitutionValidationResult(
-                allowed=False,
-                risk_level=RiskLevel.BLOCKED,
-                message="Empty command list in substitution",
-            )
 
         inner_results: list[SubstitutionValidationResult] = []
         max_risk = RiskLevel.SAFE

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,7 @@
 """Tests for BashCommandParser."""
 
+import logging
+
 import bashlex
 import pytest
 
@@ -498,5 +500,41 @@ class TestAndOrSubstitutionCorrection:
                 yp.action[st].pop("RIGHT_PAREN", None)
             parser_mod._apply_andor_substitution_correction()
         # Tables are healthy again for subsequent tests.
+        for st, val in saved.items():
+            assert yp.action[st].get("RIGHT_PAREN") == val
+
+    def test_derivation_miss_warns_not_silent(self, caplog):
+        """A spec that cannot be derived (table drift) must trigger the self-check and warn,
+        even though nothing was patched — a silent degrade to fail-closed over-block is a
+        silent failure.
+        """
+        yp = bashlex.parser.yaccparser
+        s2 = yp.goto[0]["simple_list1"]
+        states = [
+            yp.goto[yp.action[s2]["AMPERSAND"]]["simple_list1"],
+            yp.goto[yp.goto[yp.action[s2]["AND_AND"]]["newline_list"]]["simple_list1"],
+            yp.goto[yp.goto[yp.action[s2]["OR_OR"]]["newline_list"]]["simple_list1"],
+        ]
+        saved = {st: yp.action[st].get("RIGHT_PAREN") for st in states}
+        real_specs = parser_mod._ANDOR_CORRECTION_SPECS
+        try:
+            # Clear the cells so AND-OR no longer parses -> the self-check will fail.
+            for st in states:
+                yp.action[st].pop("RIGHT_PAREN", None)
+            # Every spec fails to derive a production (bogus RHS) -> missed=True, patched empty.
+            parser_mod._ANDOR_CORRECTION_SPECS = (("AMPERSAND", ("simple_list1", "NONEXISTENT"), False),)
+            with caplog.at_level(logging.WARNING, logger="schlock.core.parser"):
+                parser_mod._apply_andor_substitution_correction()
+            assert any("failed self-check" in r.message for r in caplog.records), (
+                "a derivation miss with a failing self-check must warn, not silently degrade"
+            )
+            # Nothing was patched, so nothing to revert.
+            for st in states:
+                assert yp.action[st].get("RIGHT_PAREN") is None
+        finally:
+            parser_mod._ANDOR_CORRECTION_SPECS = real_specs
+            for st in states:
+                yp.action[st].pop("RIGHT_PAREN", None)
+            parser_mod._apply_andor_substitution_correction()
         for st, val in saved.items():
             assert yp.action[st].get("RIGHT_PAREN") == val

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,9 @@
 """Tests for BashCommandParser."""
 
+import bashlex
 import pytest
 
+from schlock.core import parser as parser_mod
 from schlock.exceptions import ParseError
 
 
@@ -333,3 +335,168 @@ class TestEvalExecDetection:
         assert has_eval_exec == should_detect, (
             f"{description}: command='{command}' expected detect={should_detect}, got {has_eval_exec}. dangers={dangers}"
         )
+
+
+def _inner_subst_command(nodes):
+    """Return the `command` node inside the first command-substitution reachable from `nodes`.
+
+    Accepts either a single node or the list returned by ``parser.parse``.
+    """
+    found = []
+
+    def walk(n):
+        if found:
+            return
+        if getattr(n, "kind", None) == "commandsubstitution":
+            found.append(n.command)
+            return
+        for attr in ("parts", "command", "list"):
+            child = getattr(n, attr, None)
+            if isinstance(child, list):
+                for item in child:
+                    walk(item)
+            elif child is not None and hasattr(child, "kind"):
+                walk(child)
+
+    if isinstance(nodes, list):
+        for node in nodes:
+            walk(node)
+    else:
+        walk(nodes)
+    return found[0] if found else None
+
+
+def _op_signature(node):
+    """Flatten a node into a list of operator ops + leaf words, in source order."""
+    sig = []
+
+    def walk(n):
+        kind = getattr(n, "kind", None)
+        if kind == "operator":
+            sig.append(("op", n.op))
+        elif kind == "word" and not getattr(n, "parts", None):
+            sig.append(("word", n.word))
+        for attr in ("parts", "command", "list"):
+            child = getattr(n, attr, None)
+            if isinstance(child, list):
+                for item in child:
+                    walk(item)
+            elif child is not None and hasattr(child, "kind"):
+                walk(child)
+
+    walk(node)
+    return sig
+
+
+class TestAndOrSubstitutionCorrection:
+    """The vendored bashlex grammar correction for AND-OR lists inside $( ) (issue #96).
+
+    Without the correction, &&/||/& inside a command substitution raise ParsingError, which the
+    fail-closed validator turns into a hard block of legitimate commands.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo $(a && b)",
+            "echo $(a || b)",
+            "echo $(a & b)",
+            "echo $(a && b && c)",
+            "echo $(a || b || c)",
+            "echo $(a && b || c)",
+            "echo $(a; b && c)",
+            'X=$(cd "$(git rev-parse --git-dir)" && pwd)',
+            "echo $(a &&\n b)",
+            "diff <(a && b) <(c)",
+        ],
+    )
+    def test_andor_lists_inside_substitution_now_parse(self, parser, command):
+        """AND-OR list operators inside $( ) parse instead of raising ParseError."""
+        ast = parser.parse(command)
+        assert ast is not None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo $(a &&)",
+            "echo $(&& a)",
+            "echo $(a ||)",
+            "echo $(a && && b)",
+        ],
+    )
+    def test_malformed_lists_still_rejected(self, parser, command):
+        """The correction must not make bashlex accept malformed bash (no over-lenience)."""
+        with pytest.raises(ParseError):
+            parser.parse(command)
+
+    @pytest.mark.parametrize(
+        "inner",
+        ["a && b", "a || b && c", "a & b", "a; b && c"],
+    )
+    def test_substitution_ast_matches_top_level(self, parser, inner):
+        """The inner list AST must be structurally identical to the same list parsed top-level.
+
+        Security-critical: the validator walks this AST, so a mis-parse that under-represented the
+        operators or commands would let danger through. The flat list/operator signature of the
+        substitution body must equal the top-level parse.
+        """
+        sub_ast = parser.parse(f"echo $({inner})")
+        inner_cmd = _inner_subst_command(sub_ast)
+        assert inner_cmd is not None
+        top_ast = parser.parse(inner)
+        assert _op_signature(inner_cmd) == _op_signature(top_ast[0])
+
+    def test_correction_is_idempotent(self):
+        """Re-running the correction never clobbers existing actions (guarded fill-only-None)."""
+        yp = bashlex.parser.yaccparser
+        s2 = yp.goto[0]["simple_list1"]
+        amp_state = yp.goto[yp.action[s2]["AMPERSAND"]]["simple_list1"]
+        before = yp.action[amp_state].get("RIGHT_PAREN")
+        assert before is not None  # applied at import
+        parser_mod._apply_andor_substitution_correction()
+        assert yp.action[amp_state].get("RIGHT_PAREN") == before
+
+    def test_self_check_reverts_on_bad_table(self):
+        """If the derived reduce is wrong (self-check fails), every patched cell is reverted.
+
+        This guards the fail-closed degrade path: a future bashlex/arch table drift must fall back
+        to today's conservative over-block, never to a structurally wrong AST.
+
+        We swap ``bashlex.parse`` by hand (not the monkeypatch fixture) so the restore in ``finally``
+        runs with the REAL parser — otherwise the self-check would fail again and never restore the
+        shared parse tables, breaking every later test.
+        """
+        yp = bashlex.parser.yaccparser
+        s2 = yp.goto[0]["simple_list1"]
+        states = [
+            yp.goto[yp.action[s2]["AMPERSAND"]]["simple_list1"],
+            yp.goto[yp.goto[yp.action[s2]["AND_AND"]]["newline_list"]]["simple_list1"],
+            yp.goto[yp.goto[yp.action[s2]["OR_OR"]]["newline_list"]]["simple_list1"],
+        ]
+        saved = {st: yp.action[st].get("RIGHT_PAREN") for st in states}
+        real_parse = bashlex.parse
+        try:
+            # Reset to virgin (cells absent) so the guarded patch will re-apply.
+            for st in states:
+                yp.action[st].pop("RIGHT_PAREN", None)
+
+            # Force the self-check to fail: a "must parse" form raises.
+            def fake_parse(s, *a, **k):
+                if s == "echo $(a && b)":
+                    raise bashlex.errors.ParsingError("forced", s, 0)
+                return real_parse(s, *a, **k)
+
+            bashlex.parse = fake_parse
+            parser_mod._apply_andor_substitution_correction()
+
+            # Reverted: cells back to absent, not left half-patched.
+            for st in states:
+                assert yp.action[st].get("RIGHT_PAREN") is None
+        finally:
+            bashlex.parse = real_parse  # restore BEFORE re-applying the correction
+            for st in states:
+                yp.action[st].pop("RIGHT_PAREN", None)
+            parser_mod._apply_andor_substitution_correction()
+        # Tables are healthy again for subsequent tests.
+        for st, val in saved.items():
+            assert yp.action[st].get("RIGHT_PAREN") == val

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -538,3 +538,52 @@ class TestAndOrSubstitutionCorrection:
             parser_mod._apply_andor_substitution_correction()
         for st, val in saved.items():
             assert yp.action[st].get("RIGHT_PAREN") == val
+
+    def test_correction_never_breaks_import_on_unexpected_error(self, caplog):
+        """Any unexpected error while poking the tables is swallowed (best-effort) and warned —
+        the import must never break, it just degrades to the fail-closed over-block.
+        """
+        real_yacc = bashlex.parser.yaccparser
+
+        class _Boom:
+            goto: dict = {}
+            productions: list = []
+
+            @property
+            def action(self):
+                raise RuntimeError("simulated table access failure")
+
+        try:
+            bashlex.parser.yaccparser = _Boom()
+            with caplog.at_level(logging.WARNING, logger="schlock.core.parser"):
+                parser_mod._apply_andor_substitution_correction()  # must not raise
+            assert any("could not be applied" in r.message for r in caplog.records)
+        finally:
+            bashlex.parser.yaccparser = real_yacc
+            parser_mod._apply_andor_substitution_correction()  # restore the real correction
+
+    def test_continuation_state_drift_paths(self, caplog):
+        """A drifted action table (missing shift / missing newline_list goto) makes the state
+        walk return None for every operator -> nothing patched, but the miss still warns.
+
+        Crafted tables exercise both `continuation_state` early-return branches:
+        AMPERSAND/OR_OR have no shift action (missing key); AND_AND shifts to a state whose goto
+        lacks `newline_list`.
+        """
+        real_yacc = bashlex.parser.yaccparser
+
+        class _Drifted:
+            # goto[0]['simple_list1'] = 1 ; action[1] only has AND_AND -> 5 ; goto[5] lacks newline_list
+            goto = {0: {"simple_list1": 1}, 5: {}}
+            action = {1: {"AND_AND": 5}}
+            productions: list = []
+
+        try:
+            bashlex.parser.yaccparser = _Drifted()
+            with caplog.at_level(logging.WARNING, logger="schlock.core.parser"):
+                parser_mod._apply_andor_substitution_correction()  # must not raise
+            # No cell could be derived, so nothing was added to the drifted action table.
+            assert "RIGHT_PAREN" not in _Drifted.action.get(1, {})
+        finally:
+            bashlex.parser.yaccparser = real_yacc
+            parser_mod._apply_andor_substitution_correction()  # restore the real correction

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -16,7 +16,7 @@ from schlock.core.substitution import (
     SubstitutionValidationResult,
     SubstitutionValidator,
 )
-from schlock.core.validator import load_rules
+from schlock.core.validator import load_rules, validate_command
 
 
 @pytest.fixture
@@ -223,9 +223,8 @@ class TestCompoundCommandCoverage:
             assert subs[0].substitution_type == SubstitutionType.COMMAND
 
     def test_command_list_in_substitution(self, validator, parser):
-        """Command lists should be handled."""
-        # Note: bashlex doesn't handle $(cmd1 && cmd2) well, use semicolon instead
-        ast = parser.parse("echo $(pwd; date)")
+        """Command lists should be handled, including && / || (see _apply_andor_substitution_correction)."""
+        ast = parser.parse("echo $(pwd && date)")
         subs = validator.extract_substitutions(ast)
         if subs:
             assert subs[0].substitution_type == SubstitutionType.COMMAND
@@ -1465,7 +1464,13 @@ class TestRemainingBranchCoverage:
         assert result is not None
 
     def test_list_operator_without_op(self, validator):
-        """List with operator that has no 'op' attribute."""
+        """A list operator missing its 'op' attribute renders to None (fail closed).
+
+        Real bashlex operators always carry 'op'; a missing one is a malformed/synthetic node.
+        Rather than emit "echo" and silently drop the unknown connector (which would
+        misrepresent the command to the rule engine and audit log), the renderer fails closed.
+        The list substitution is still validated per-segment from its AST.
+        """
 
         class MockWord:
             word = "echo"
@@ -1486,8 +1491,7 @@ class TestRemainingBranchCoverage:
             command = MockList()
 
         result = validator._extract_inner_command_text(MockNode())
-        assert result is not None
-        assert "echo" in result
+        assert result is None
 
     def test_list_part_without_parts(self, validator):
         """List command part without 'parts' attribute."""
@@ -1689,3 +1693,66 @@ class TestRemainingBranchCoverage:
 
         result = validator.extract_substitutions([MockCmd()])
         assert isinstance(result, list)
+
+
+class TestAndOrListSegmentValidation:
+    """Per-segment validation of && / || / ; / & lists inside $( ) (issue #96, Piece 2).
+
+    Each segment is validated independently; the list is allowed only if every segment is.
+    These cases were all hard-blocked before the grammar correction (ParseError -> fail closed).
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "$(date && pwd)"',
+            'echo "$(cd /tmp && ls)"',
+            'echo "$(pwd; whoami)"',
+            'echo "$(git rev-parse HEAD && date)"',
+            'echo "$(date & pwd)"',
+            'echo "$(cd /tmp && ls && pwd && date)"',
+            'echo "$(date && echo $(whoami))"',
+        ],
+    )
+    def test_all_safe_segments_allowed(self, validator, parser, command):
+        """A list whose every segment is safe/whitelisted is allowed."""
+        ast = parser.parse(command)
+        results = validator.validate_all_substitutions(ast)
+        assert results, "expected at least one substitution result"
+        assert all(r.allowed for r in results), [r.message for r in results if not r.allowed]
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "$(date; rm -rf /)"',  # blacklisted later segment
+            'echo "$(true && rm -rf /)"',
+            'echo "$(rm -rf / & pwd)"',  # blacklisted first segment, backgrounded
+            'echo "$(date && unknowncmd)"',  # unknown later segment -> default deny
+            'echo "$(date && echo $(rm -rf /))"',  # nested substitution inside a segment
+            'echo "$(pwd && git -c core.sshCommand=rm fetch)"',  # dangerous git config in a segment
+            'echo "$(date && { rm -rf /; })"',  # compound segment -> fail closed
+            'echo "$(date && (rm -rf /))"',  # subshell compound segment -> fail closed
+        ],
+    )
+    def test_dangerous_segment_blocks_whole_list(self, validator, parser, command):
+        """If any segment is dangerous/unrenderable the whole list is blocked."""
+        ast = parser.parse(command)
+        results = validator.validate_all_substitutions(ast)
+        assert results, "expected at least one substitution result"
+        assert any(not r.allowed for r in results), "expected the list to be blocked"
+
+    def test_canonical_repro_allowed_end_to_end(self):
+        """The canonical #96 repro is allowed by the top-level validator regardless of preset."""
+        result = validate_command('X=$(cd "$(git rev-parse --git-dir)" && pwd)')
+        assert result.allowed, result.message
+
+    def test_inner_command_text_renders_pipeline_segment(self, validator, parser):
+        """A pipeline segment is rendered faithfully (not truncated) for rule matching/audit."""
+        ast = parser.parse("echo $(foo && bar | baz)")
+        subs = validator.extract_substitutions(ast)
+        assert subs
+        assert subs[0].inner_command == "foo && bar | baz"
+
+    def test_cd_is_whitelisted(self, validator):
+        """cd is now a whitelisted substitution command (subshell-pure)."""
+        assert validator.is_whitelisted("cd")

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -1811,3 +1811,130 @@ class TestAndOrListSegmentValidation:
     def test_cd_is_whitelisted(self, validator):
         """cd is now a whitelisted substitution command (subshell-pure)."""
         assert validator.is_whitelisted("cd")
+
+
+def _mock(kind, **attrs):
+    return type("_Mock", (), {"kind": kind, **attrs})()
+
+
+class TestListSegmentBranchCoverage:
+    """Direct branch coverage of the per-segment list helpers (issue #96)."""
+
+    # --- _segment_base_command ---
+
+    def test_segment_base_command_command_without_word(self, validator):
+        """A command segment with no leading word -> None (fail-closed base)."""
+        assert validator._segment_base_command(_mock("command", parts=[])) is None
+
+    def test_segment_base_command_pipeline_first_command(self, validator):
+        """A pipeline segment resolves to the first command's first word."""
+        pipeline = _mock(
+            "pipeline",
+            parts=[_mock("command", parts=[_mock("word", word="grep")]), _mock("pipe"), _mock("command", parts=[])],
+        )
+        assert validator._segment_base_command(pipeline) == "grep"
+
+    def test_segment_base_command_pipeline_command_without_word(self, validator):
+        """A pipeline whose first command has no word -> None."""
+        pipeline = _mock("pipeline", parts=[_mock("command", parts=[])])
+        assert validator._segment_base_command(pipeline) is None
+
+    def test_segment_base_command_pipeline_without_command(self, validator):
+        """A pipeline with no command part (e.g. only a reserved word) -> None."""
+        pipeline = _mock("pipeline", parts=[_mock("reservedword")])
+        assert validator._segment_base_command(pipeline) is None
+
+    def test_segment_base_command_compound_returns_none(self, validator):
+        """A compound segment has no leading word -> None."""
+        assert validator._segment_base_command(_mock("compound")) is None
+
+    # --- _render_segment_text ---
+
+    def test_render_segment_text_command_without_words(self, validator):
+        """A command with no words renders to None (fail-closed)."""
+        assert validator._render_segment_text(_mock("command", parts=[])) is None
+
+    def test_render_segment_text_pipeline(self, validator):
+        """A pipeline renders as 'cmd | cmd' with words preserved."""
+        pipeline = _mock(
+            "pipeline",
+            parts=[
+                _mock("command", parts=[_mock("word", word="grep"), _mock("word", word="x")]),
+                _mock("pipe"),
+                _mock("command", parts=[_mock("word", word="head")]),
+            ],
+        )
+        assert validator._render_segment_text(pipeline) == "grep x | head"
+
+    def test_render_segment_text_pipeline_with_reserved_word(self, validator):
+        """A pipeline containing a reserved word (e.g. `!`) is unrenderable -> None."""
+        pipeline = _mock("pipeline", parts=[_mock("reservedword"), _mock("command", parts=[_mock("word", word="x")])])
+        assert validator._render_segment_text(pipeline) is None
+
+    def test_render_segment_text_pipeline_command_without_words(self, validator):
+        """A pipeline whose command has no words is unrenderable -> None."""
+        pipeline = _mock("pipeline", parts=[_mock("command", parts=[])])
+        assert validator._render_segment_text(pipeline) is None
+
+    def test_render_segment_text_compound_returns_none(self, validator):
+        """A compound segment cannot be rendered faithfully -> None."""
+        assert validator._render_segment_text(_mock("compound")) is None
+
+    # --- _extract_base_command list branch (operator handling) ---
+
+    def test_extract_base_command_list_skips_leading_operator(self, validator):
+        """A leading operator slot is skipped; the first real segment supplies the base command."""
+        node = _mock(
+            "x",
+            command=_mock(
+                "list",
+                parts=[_mock("operator", op="&&"), _mock("command", parts=[_mock("word", word="date")])],
+            ),
+        )
+        # _extract_base_command reads node.command
+        assert validator._extract_base_command(node) == "date"
+
+    def test_extract_base_command_list_all_operators(self, validator):
+        """A list of only operators yields no base command -> None."""
+        node = _mock("x", command=_mock("list", parts=[_mock("operator", op="&&"), _mock("operator", op="||")]))
+        assert validator._extract_base_command(node) is None
+
+    # --- _validate_list_segments: cross-segment rule match + risk aggregation ---
+
+    def test_cross_segment_rule_match_blocks(self, parser):
+        """The full rendered list text is re-checked against the rules even when every segment
+        passes individually; a HIGH/BLOCKED match blocks the whole list (defense-in-depth)."""
+
+        class _Match:
+            matched = True
+            risk_level = RiskLevel.HIGH
+            message = "mock cross-segment rule"
+
+        class _Engine:
+            def match_command(self, command):  # noqa: ARG002
+                return _Match()
+
+        v = SubstitutionValidator(parser, _Engine())
+        ast = parser.parse('echo "$(date && pwd)"')  # both segments whitelisted -> pass per-segment
+        results = v.validate_all_substitutions(ast)
+        assert results and not results[0].allowed
+        assert "Inner command blocked" in results[0].message
+
+    def test_list_segment_risk_aggregation(self, validator, parser):
+        """The combined risk is the max over segments (verified by forcing a non-SAFE allowed
+        segment — synthetic, since real allowed segments are always SAFE)."""
+        ast = parser.parse('echo "$(date && pwd)"')
+        sub = validator.extract_substitutions(ast)[0]
+        cmd_node = sub.ast_node.command
+        original = validator.validate_substitution
+
+        def fake(child, depth):  # noqa: ARG001
+            return SubstitutionValidationResult(allowed=True, risk_level=RiskLevel.MEDIUM, message="x")
+
+        validator.validate_substitution = fake
+        try:
+            result = validator._validate_list_segments(sub, cmd_node, 0)
+        finally:
+            validator.validate_substitution = original
+        assert result.allowed
+        assert result.risk_level == RiskLevel.MEDIUM

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -1710,6 +1710,7 @@ class TestAndOrListSegmentValidation:
             'echo "$(pwd; whoami)"',
             'echo "$(git rev-parse HEAD && date)"',
             'echo "$(date & pwd)"',
+            'echo "$(true || date)"',  # OR operator, both segments safe
             'echo "$(cd /tmp && ls && pwd && date)"',
             'echo "$(date && echo $(whoami))"',
         ],
@@ -1726,6 +1727,7 @@ class TestAndOrListSegmentValidation:
         [
             'echo "$(date; rm -rf /)"',  # blacklisted later segment
             'echo "$(true && rm -rf /)"',
+            'echo "$(date || rm -rf /)"',  # OR operator, blacklisted second segment
             'echo "$(rm -rf / & pwd)"',  # blacklisted first segment, backgrounded
             'echo "$(date && unknowncmd)"',  # unknown later segment -> default deny
             'echo "$(date && echo $(rm -rf /))"',  # nested substitution inside a segment
@@ -1740,6 +1742,59 @@ class TestAndOrListSegmentValidation:
         results = validator.validate_all_substitutions(ast)
         assert results, "expected at least one substitution result"
         assert any(not r.allowed for r in results), "expected the list to be blocked"
+
+    @pytest.mark.parametrize(
+        "parts_spec,expected",
+        [
+            ([("command", None), ("operator", "&&"), ("command", None)], True),
+            ([("command", None), ("operator", ";"), ("command", None)], True),
+            ([("pipeline", None), ("operator", "||"), ("command", None)], True),
+            ([("command", None)], True),  # degenerate single segment
+            ([], False),  # empty
+            ([("command", None), ("operator", "&&")], False),  # trailing operator (even length)
+            ([("command", None), ("operator", None), ("command", None)], False),  # op missing .op
+            ([("command", None), ("operator", "XX"), ("command", None)], False),  # unrecognized op
+            ([("operator", "&&"), ("command", None), ("command", None)], False),  # op in segment slot
+        ],
+    )
+    def test_list_topology_validation(self, validator, parts_spec, expected):
+        """_is_valid_list_topology accepts only strictly alternating, segment-terminated lists."""
+
+        def make(kind, op):
+            attrs = {"kind": kind}
+            if op is not None:
+                attrs["op"] = op
+            return type("_Part", (), attrs)()
+
+        parts = [make(kind, op) for kind, op in parts_spec]
+        assert validator._is_valid_list_topology(parts) is expected
+
+    def test_malformed_list_topology_blocked_end_to_end(self, validator):
+        """A malformed list AST (operator without op) blocks instead of validating surviving segments."""
+
+        class _Op:
+            kind = "operator"  # deliberately no .op attribute
+
+        class _Cmd:
+            kind = "command"
+            parts: list = []
+
+        class _List:
+            kind = "list"
+            parts = [_Cmd(), _Op()]  # even length + op-less operator
+
+        class _Node:
+            command = _List()
+
+        sub = SubstitutionNode(
+            substitution_type=SubstitutionType.COMMAND,
+            inner_command=None,
+            base_command=None,
+            ast_node=_Node(),
+        )
+        result = validator.validate_substitution(sub)
+        assert not result.allowed
+        assert "Malformed list topology" in result.message
 
     def test_canonical_repro_allowed_end_to_end(self):
         """The canonical #96 repro is allowed by the top-level validator regardless of preset."""


### PR DESCRIPTION
## Summary

Fixes the bashlex fail-closed over-block for AND-OR lists (`&&` / `||` / `&`) inside command substitutions `$( … )`. bashlex 0.18 only accepts `;`-separated lists there; an AND-OR operator raises `ParsingError`, which the fail-closed safety validator turns into a hard block of legitimate commands like `X=$(cd "$(git rev-parse --git-dir)" && pwd)` — regardless of risk preset.

Upstream (idank/bashlex#54) is unfixed and 0.18 is the latest release, so the fix lives here.

**Root cause:** bashlex's own import-time table hack `get_correction_rightparen_states` adds `RIGHT_PAREN` acceptance only to the SEMICOLON continuation state. The sibling AMPERSAND / AND_AND / OR_OR states have no `RIGHT_PAREN` action, so the closing `)` of the substitution lands on an error cell.

## Changes

Four coupled changes, all in `src/schlock/core/{parser,substitution}.py` — **no vendored-fork edit**. The correction is applied at import to whichever `bashlex.parser.yaccparser` is loaded (vendored at plugin runtime, `.venv` in tests), so it's testable and needs no `parsetab.py` regen.

1. **`parser.py` — `_apply_andor_substitution_correction()`** mirrors bashlex's technique for the three AND-OR continuation states. States and reduce-productions are discovered by table-walk (never hardcoded); a cell is filled **only when absent** — an LALR parse never visits an error cell, so this cannot change any input that already parsed. A self-check reverts every patched cell and logs a warning if the table ever drifts (new bashlex / arch), degrading to today's fail-closed over-block rather than risking a structurally wrong AST.

2. **`substitution.py` — per-segment list validation.** `validate_substitution` intercepts `kind == "list"` before the whitelist fast-path and runs each non-operator segment through the full validation pipeline at the same depth; the list is allowed only if every segment is, blocked on the first dangerous/unrenderable one. This also fixes the `;`-list over-block (`$(date; pwd)`) and closes a fail-open: list nodes now survive partial text rendering (a compound segment) so they are still validated structurally.

3. **`substitution.py` — faithful text rendering.** `_extract_inner_command_text` renders list segments faithfully (pipelines included) or returns `None` to fail closed, instead of silently dropping pipeline/compound segments (`$(foo && bar | rm -rf /)` no longer renders as `foo &&`). `_extract_base_command` gains a list branch.

4. **`substitution.py` — whitelist `cd`** (subshell-pure inside `$()`).

## Verification

- **39 new tests** (`TestAndOrSubstitutionCorrection` in `test_parser.py`, `TestAndOrListSegmentValidation` in `test_substitution.py`) covering parse success, malformed-bash rejection, AST-shape equivalence vs top-level parse, the allow/block matrix, nested substitutions in segments, compound/pipeline segments, and the self-check revert path.
- Full suite green (the only 2 failures are the pre-existing `test_high_*` config-isolation bug, unrelated to this change).
- ruff lint + format clean.
- **Differential fuzz vs `bash -n` over 762 cases on both the `.venv` and vendored bashlex copies → zero cases where bashlex accepts what bash rejects** (no mis-parse), only safe over-blocks on trailing-operator edges.

## Scope

Closes #96.

For #106: the heredoc half is already handled by `_validate_heredoc_command` (non-issue, verified); the arithmetic `$(( ))` half is a separate bashlex `handleNotImplemented` gap, filed as #112.

Out of scope (filed separately):
- Arithmetic `$(( ))` substitutions — #112.
- Write-via-arg gap (`sort -o` / `tee` / `xxd -r … FILE` / `sdiff -o` write arbitrary files) — already allowed at top level and in simple `$()`; this PR doesn't change that and opens no new path — #113.
