### PR TITLE
fix(validator): block write-via-arg file writes (sort/sdiff/xxd) (#113)

### DIFF
--- a/data/rules/08_system_modification.yaml
+++ b/data/rules/08_system_modification.yaml
@@ -105,9 +105,9 @@ rules:
       # -ro (-r + -o). The /etc/cron (and similar) prefixes intentionally match anything beneath
       # those dirs — writing under /etc at all is privileged. [^;|&\n] cannot cross a command
       # boundary or newline (avoids cross-command misattribution). See #113.
-      - '\b(sort|sdiff)\b[^;|&\n]*(-[a-zA-Z]*o|--output)[=\s]+["\x27]?(~/?\.(bashrc|bash_profile|zshrc|profile|login)|\$HOME/\.(bashrc|bash_profile|zshrc|profile|login)|~/?\.ssh/authorized_keys|\$HOME/\.ssh/authorized_keys|/root/|/etc/cron|/var/spool/cron|/etc/sudoers|/etc/profile|/etc/bash\.bashrc|/etc/environment|/etc/passwd|/etc/shadow|/etc/ld\.so|/etc/systemd|/(usr/)?lib/systemd)'
+      - '\b(sort|sdiff)\b[^;|&\n]*(-[a-zA-Z]*o|--output)[=\s]+["\x27]?(~/?\.(bashrc|bash_profile|zshrc|profile|login)|\$HOME/\.(bashrc|bash_profile|zshrc|profile|login)|\$\{HOME\}/\.(bashrc|bash_profile|zshrc|profile|login)|~/?\.ssh/authorized_keys|\$HOME/\.ssh/authorized_keys|\$\{HOME\}/\.ssh/authorized_keys|/root/|/etc/cron|/var/spool/cron|/etc/sudoers|/etc/profile|/etc/bash\.bashrc|/etc/environment|/etc/passwd|/etc/shadow|/etc/ld\.so|/etc/systemd|/(usr/)?lib/systemd)'
       # attached short form: -o<sensitive-path> or -ro<sensitive-path>
-      - '\b(sort|sdiff)\b[^;|&\n]*-[a-zA-Z]*o["\x27]?(~/?\.(bashrc|bash_profile|zshrc|profile|login)|\$HOME/\.(bashrc|bash_profile|zshrc|profile|login)|~/?\.ssh/authorized_keys|\$HOME/\.ssh/authorized_keys|/root/|/etc/cron|/var/spool/cron|/etc/sudoers|/etc/profile|/etc/bash\.bashrc|/etc/environment|/etc/passwd|/etc/shadow|/etc/ld\.so|/etc/systemd|/(usr/)?lib/systemd)'
+      - '\b(sort|sdiff)\b[^;|&\n]*-[a-zA-Z]*o["\x27]?(~/?\.(bashrc|bash_profile|zshrc|profile|login)|\$HOME/\.(bashrc|bash_profile|zshrc|profile|login)|\$\{HOME\}/\.(bashrc|bash_profile|zshrc|profile|login)|~/?\.ssh/authorized_keys|\$HOME/\.ssh/authorized_keys|\$\{HOME\}/\.ssh/authorized_keys|/root/|/etc/cron|/var/spool/cron|/etc/sudoers|/etc/profile|/etc/bash\.bashrc|/etc/environment|/etc/passwd|/etc/shadow|/etc/ld\.so|/etc/systemd|/(usr/)?lib/systemd)'
     alternatives:
       - "Writing to a system config/persistence path via -o is a backdoor vector"
       - "Write to a non-system path, or use proper configuration management"

--- a/data/rules/08_system_modification.yaml
+++ b/data/rules/08_system_modification.yaml
@@ -96,6 +96,22 @@ rules:
       - "Attackers use this for backdoor persistence"
       - "Use proper configuration management instead"
 
+  - name: write_via_arg_persistence
+    description: sort/sdiff writing output (-o) to a sensitive system path enables persistence or privilege escalation
+    risk_level: HIGH
+    patterns:
+      # sort/sdiff -o / --output (cluster ending in 'o', e.g. -o or -ro), space/'='-separated,
+      # optional quote, then a sensitive target. '-[a-zA-Z]*o' catches combined short flags like
+      # -ro (-r + -o). The /etc/cron (and similar) prefixes intentionally match anything beneath
+      # those dirs — writing under /etc at all is privileged. [^;|&\n] cannot cross a command
+      # boundary or newline (avoids cross-command misattribution). See #113.
+      - '\b(sort|sdiff)\b[^;|&\n]*(-[a-zA-Z]*o|--output)[=\s]+["\x27]?(~/?\.(bashrc|bash_profile|zshrc|profile|login)|\$HOME/\.(bashrc|bash_profile|zshrc|profile|login)|~/?\.ssh/authorized_keys|\$HOME/\.ssh/authorized_keys|/root/|/etc/cron|/var/spool/cron|/etc/sudoers|/etc/profile|/etc/bash\.bashrc|/etc/environment|/etc/passwd|/etc/shadow|/etc/ld\.so|/etc/systemd|/(usr/)?lib/systemd)'
+      # attached short form: -o<sensitive-path> or -ro<sensitive-path>
+      - '\b(sort|sdiff)\b[^;|&\n]*-[a-zA-Z]*o["\x27]?(~/?\.(bashrc|bash_profile|zshrc|profile|login)|\$HOME/\.(bashrc|bash_profile|zshrc|profile|login)|~/?\.ssh/authorized_keys|\$HOME/\.ssh/authorized_keys|/root/|/etc/cron|/var/spool/cron|/etc/sudoers|/etc/profile|/etc/bash\.bashrc|/etc/environment|/etc/passwd|/etc/shadow|/etc/ld\.so|/etc/systemd|/(usr/)?lib/systemd)'
+    alternatives:
+      - "Writing to a system config/persistence path via -o is a backdoor vector"
+      - "Write to a non-system path, or use proper configuration management"
+
   - name: system_service_modification
     description: System configuration and startup modification
     risk_level: HIGH

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -557,6 +557,19 @@ def dangerous_kubectl(args: list[str]) -> str | None:  # noqa: PLR0911, PLR0912 
 _WRITE_ARG_COMMANDS: frozenset[str] = frozenset({"sort", "sdiff", "xxd"})
 
 
+def _options_before_double_dash(args: list[str]) -> Iterator[str]:
+    """Yield tokens up to a ``--`` end-of-options marker (exclusive).
+
+    After ``--`` the shell treats everything as positionals, so a later ``-o``/``-r`` is a filename,
+    not a flag, and must not be scanned as a write flag (e.g. ``sort -- -o`` reads a file named
+    ``-o``). See #113.
+    """
+    for arg in args:
+        if arg == "--":
+            return
+        yield arg
+
+
 def dangerous_write_arg(base_command: str, args: list[str]) -> str | None:
     """Return a reason if `base_command` writes to a file via its arguments, else None.
 
@@ -569,7 +582,7 @@ def dangerous_write_arg(base_command: str, args: list[str]) -> str | None:
         return None
 
     if base_command in ("sort", "sdiff"):
-        for arg in args:
+        for arg in _options_before_double_dash(args):
             # long form: --output or --output=FILE
             if arg == "--output" or arg.startswith("--output="):
                 return f"{base_command} -o writes output to a file"
@@ -580,7 +593,7 @@ def dangerous_write_arg(base_command: str, args: list[str]) -> str | None:
             if arg.startswith("-") and not arg.startswith("--") and "o" in arg[1:]:
                 return f"{base_command} -o writes output to a file"
     elif base_command == "xxd":
-        for arg in args:
+        for arg in _options_before_double_dash(args):
             if arg in ("-r", "--reverse"):
                 return "xxd -r decodes hex to raw bytes (write/obfuscation vector)"
             # combined short flags, e.g. -rp / -pr

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -1104,6 +1104,14 @@ class SubstitutionValidator:
                 if kubectl_reason:
                     return True, kubectl_reason
 
+            # Write-via-arg: sort/sdiff/xxd are whitelisted and would otherwise take the SAFE fast
+            # path, bypassing the YAML rules that catch these at the top level. Blunt: any write
+            # target inside a substitution is dangerous. See #113.
+            if base_command in _WRITE_ARG_COMMANDS and args:
+                write_reason = dangerous_write_arg(base_command, args)
+                if write_reason:
+                    return True, write_reason
+
         return False, ""
 
     def _check_structural_and_nested(self, sub_node: SubstitutionNode, depth: int) -> SubstitutionValidationResult | None:

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -547,6 +547,49 @@ def dangerous_kubectl(args: list[str]) -> str | None:  # noqa: PLR0911, PLR0912 
     return None
 
 
+# Commands that write to a file via an ARGUMENT (not a shell redirect). Inside a substitution any
+# such write is dangerous: a substitution's job is to produce a value, so a file write as a side
+# effect is suspicious — mirrors the "any output redirection in $() is BLOCKED" rule. These three
+# are also in SAFE_SUBSTITUTION_COMMANDS, so without this check they take the whitelist fast path
+# and bypass the YAML rules that would catch them at the top level. `tee` is intentionally absent:
+# it is not whitelisted, never reaches _has_dangerous_inner_structure, and is already BLOCKED in
+# substitution by the truncation YAML rule. See #113.
+_WRITE_ARG_COMMANDS: frozenset[str] = frozenset({"sort", "sdiff", "xxd"})
+
+
+def dangerous_write_arg(base_command: str, args: list[str]) -> str | None:
+    """Return a reason if `base_command` writes to a file via its arguments, else None.
+
+    Pure; the single source of truth for the SubstitutionValidator's write-via-arg check. `args` is
+    the command's word list and may include the leading command token (harmless to the flag scans
+    below). Blunt by design — ANY write target is dangerous inside a substitution, regardless of the
+    destination path. See #113.
+    """
+    if base_command not in _WRITE_ARG_COMMANDS:
+        return None
+
+    if base_command in ("sort", "sdiff"):
+        for arg in args:
+            # long form: --output or --output=FILE
+            if arg == "--output" or arg.startswith("--output="):
+                return f"{base_command} -o writes output to a file"
+            # Any short-flag cluster containing 'o' is sort/sdiff's -o (write output to a file):
+            # covers -o, -ofile, -ro, -rofile. 'o' is the ONLY short flag of sort/sdiff that uses
+            # that letter, so an attached value char ('o' as another flag's value, e.g. -to) only
+            # ever over-matches — an acceptable blunt over-block inside a substitution. See #113.
+            if arg.startswith("-") and not arg.startswith("--") and "o" in arg[1:]:
+                return f"{base_command} -o writes output to a file"
+    elif base_command == "xxd":
+        for arg in args:
+            if arg in ("-r", "--reverse"):
+                return "xxd -r decodes hex to raw bytes (write/obfuscation vector)"
+            # combined short flags, e.g. -rp / -pr
+            if arg.startswith("-") and not arg.startswith("--") and "r" in arg[1:]:
+                return "xxd -r decodes hex to raw bytes (write/obfuscation vector)"
+
+    return None
+
+
 @dataclass
 class SubstitutionNode:
     """Represents a command or process substitution in the AST."""

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -1105,8 +1105,10 @@ class SubstitutionValidator:
                     return True, kubectl_reason
 
             # Write-via-arg: sort/sdiff/xxd are whitelisted and would otherwise take the SAFE fast
-            # path, bypassing the YAML rules that catch these at the top level. Blunt: any write
-            # target inside a substitution is dangerous. See #113.
+            # path, bypassing the YAML rules that catch these at the top level (sort/sdiff ->
+            # write_via_arg_persistence in 08_system_modification.yaml; xxd -> code_obfuscation in
+            # 05_code_execution.yaml). Blunt: any write target inside a substitution is dangerous.
+            # See #113.
             if base_command in _WRITE_ARG_COMMANDS and args:
                 write_reason = dangerous_write_arg(base_command, args)
                 if write_reason:

--- a/tests/test_write_via_arg.py
+++ b/tests/test_write_via_arg.py
@@ -1,6 +1,8 @@
 """#113: write-via-arg file writes (sort/sdiff/xxd) blocked in substitution; top-level target-aware."""
 
+from schlock.core.rules import RiskLevel
 from schlock.core.substitution import _WRITE_ARG_COMMANDS, dangerous_write_arg
+from schlock.core.validator import validate_command
 
 
 class TestDangerousWriteArgHelper:
@@ -52,3 +54,30 @@ class TestDangerousWriteArgHelper:
         }
         for cmd in _WRITE_ARG_COMMANDS:
             assert dangerous_write_arg(cmd, invocations[cmd]) is not None, cmd
+
+
+class TestWriteViaArgSubstitution:
+    """Blunt: any write-via-arg target inside a substitution is BLOCKED (#113)."""
+
+    def test_sort_output_in_command_substitution_blocked(self):
+        assert validate_command('echo "$(sort -o /etc/cron.d/pwn /tmp/payload)"').risk_level == RiskLevel.BLOCKED
+
+    def test_sdiff_output_in_substitution_blocked(self):
+        assert validate_command('echo "$(sdiff -o /etc/cron.d/pwn a b)"').risk_level == RiskLevel.BLOCKED
+
+    def test_xxd_reverse_in_substitution_blocked(self):
+        assert validate_command('echo "$(xxd -r -p payload /etc/cron.d/pwn)"').risk_level == RiskLevel.BLOCKED
+
+    def test_sort_output_to_nonsensitive_in_substitution_blocked(self):
+        # Accepted false-positive cost: writing ANY file inside $() is blunt-blocked.
+        assert validate_command('X="$(sort -o tmpfile in.txt)"').risk_level == RiskLevel.BLOCKED
+
+    def test_sort_read_only_in_substitution_still_safe(self):
+        assert validate_command('X="$(sort in.txt)"').allowed is True
+
+    def test_xxd_forward_in_substitution_still_safe(self):
+        assert validate_command('X="$(xxd -p in.txt)"').allowed is True
+
+    def test_tee_in_substitution_still_blocked_regression(self):
+        # tee is covered by the existing truncation YAML rule, not the helper.
+        assert validate_command('echo "$(tee /etc/cron.d/pwn)"').risk_level == RiskLevel.BLOCKED

--- a/tests/test_write_via_arg.py
+++ b/tests/test_write_via_arg.py
@@ -81,3 +81,36 @@ class TestWriteViaArgSubstitution:
     def test_tee_in_substitution_still_blocked_regression(self):
         # tee is covered by the existing truncation YAML rule, not the helper.
         assert validate_command('echo "$(tee /etc/cron.d/pwn)"').risk_level == RiskLevel.BLOCKED
+
+
+class TestWriteViaArgTopLevel:
+    """Target-aware: sort/sdiff -o to a SENSITIVE path -> HIGH; benign target stays SAFE (#113)."""
+
+    def test_sort_output_to_cron_is_high(self):
+        assert validate_command("sort -o /etc/cron.d/pwn payload").risk_level == RiskLevel.HIGH
+
+    def test_sort_output_equals_cron_is_high(self):
+        assert validate_command("sort --output=/etc/cron.d/pwn payload").risk_level == RiskLevel.HIGH
+
+    def test_sdiff_output_to_authorized_keys_is_high(self):
+        assert validate_command("sdiff -o ~/.ssh/authorized_keys a b").risk_level == RiskLevel.HIGH
+
+    def test_sort_output_to_benign_file_stays_safe(self):
+        # FP guard — must NOT be flagged.
+        assert validate_command("sort -o out.txt in.txt").risk_level == RiskLevel.SAFE
+
+    def test_sort_read_only_stays_safe(self):
+        assert validate_command("sort in.txt").risk_level == RiskLevel.SAFE
+
+    def test_sort_combined_short_flags_to_sensitive_is_high(self):
+        # -ro = -r (reverse) + -o (output); the top-level rule must catch the combined form
+        assert validate_command("sort -ro /etc/cron.d/pwn payload").risk_level == RiskLevel.HIGH
+
+    def test_sort_attached_output_to_sensitive_is_high(self):
+        assert validate_command("sort -o/etc/cron.d/pwn payload").risk_level == RiskLevel.HIGH
+
+    def test_sort_quoted_sensitive_target_is_high(self):
+        assert validate_command('sort -o "/etc/cron.d/pwn" payload').risk_level == RiskLevel.HIGH
+
+    def test_sort_output_to_root_ssh_is_high(self):
+        assert validate_command("sort -o /root/.ssh/authorized_keys k").risk_level == RiskLevel.HIGH

--- a/tests/test_write_via_arg.py
+++ b/tests/test_write_via_arg.py
@@ -1,0 +1,54 @@
+"""#113: write-via-arg file writes (sort/sdiff/xxd) blocked in substitution; top-level target-aware."""
+
+from schlock.core.substitution import _WRITE_ARG_COMMANDS, dangerous_write_arg
+
+
+class TestDangerousWriteArgHelper:
+    def test_sort_dash_o_space_is_dangerous(self):
+        assert dangerous_write_arg("sort", ["sort", "-o", "/etc/cron.d/x", "in"]) is not None
+
+    def test_sort_long_output_equals_is_dangerous(self):
+        assert dangerous_write_arg("sort", ["sort", "--output=/etc/cron.d/x"]) is not None
+
+    def test_sort_attached_short_is_dangerous(self):
+        assert dangerous_write_arg("sort", ["sort", "-o/etc/cron.d/x"]) is not None
+
+    def test_sort_no_output_is_safe(self):
+        assert dangerous_write_arg("sort", ["sort", "in.txt"]) is None
+
+    def test_sdiff_dash_o_is_dangerous(self):
+        assert dangerous_write_arg("sdiff", ["sdiff", "-o", "merged", "a", "b"]) is not None
+
+    def test_xxd_reverse_is_dangerous(self):
+        assert dangerous_write_arg("xxd", ["xxd", "-r", "-p", "in", "out"]) is not None
+
+    def test_xxd_combined_reverse_is_dangerous(self):
+        assert dangerous_write_arg("xxd", ["xxd", "-rp", "in", "out"]) is not None
+
+    def test_xxd_forward_is_safe(self):
+        assert dangerous_write_arg("xxd", ["xxd", "-p", "in"]) is None
+
+    def test_unrelated_command_is_safe(self):
+        assert dangerous_write_arg("cat", ["cat", "-o", "x"]) is None
+
+    def test_sort_combined_short_flags_with_output_is_dangerous(self):
+        # -ro = -r (reverse) + -o (output to file)
+        assert dangerous_write_arg("sort", ["sort", "-ro", "/etc/cron.d/x", "in"]) is not None
+
+    def test_xxd_long_reverse_is_dangerous(self):
+        assert dangerous_write_arg("xxd", ["xxd", "--reverse", "in", "out"]) is not None
+
+    def test_sdiff_attached_output_is_dangerous(self):
+        assert dangerous_write_arg("sdiff", ["sdiff", "-o/etc/cron.d/x", "a", "b"]) is not None
+
+    def test_sdiff_long_output_equals_is_dangerous(self):
+        assert dangerous_write_arg("sdiff", ["sdiff", "--output=/etc/cron.d/x", "a", "b"]) is not None
+
+    def test_every_write_arg_command_detected_with_output(self):
+        invocations = {
+            "sort": ["sort", "-o", "x"],
+            "sdiff": ["sdiff", "-o", "x", "a", "b"],
+            "xxd": ["xxd", "-r", "in", "out"],
+        }
+        for cmd in _WRITE_ARG_COMMANDS:
+            assert dangerous_write_arg(cmd, invocations[cmd]) is not None, cmd

--- a/tests/test_write_via_arg.py
+++ b/tests/test_write_via_arg.py
@@ -102,6 +102,10 @@ class TestWriteViaArgTopLevel:
     def test_sort_read_only_stays_safe(self):
         assert validate_command("sort in.txt").risk_level == RiskLevel.SAFE
 
+    def test_sdiff_output_to_benign_file_stays_safe(self):
+        # FP guard — sdiff parity with the sort benign-target guard.
+        assert validate_command("sdiff -o out.txt a b").risk_level == RiskLevel.SAFE
+
     def test_sort_combined_short_flags_to_sensitive_is_high(self):
         # -ro = -r (reverse) + -o (output); the top-level rule must catch the combined form
         assert validate_command("sort -ro /etc/cron.d/pwn payload").risk_level == RiskLevel.HIGH

--- a/tests/test_write_via_arg.py
+++ b/tests/test_write_via_arg.py
@@ -55,6 +55,16 @@ class TestDangerousWriteArgHelper:
         for cmd in _WRITE_ARG_COMMANDS:
             assert dangerous_write_arg(cmd, invocations[cmd]) is not None, cmd
 
+    def test_double_dash_ends_options_sort(self):
+        # After `--`, `-o` is a positional filename (input), not the output flag.
+        assert dangerous_write_arg("sort", ["sort", "--", "-o"]) is None
+
+    def test_double_dash_ends_options_xxd(self):
+        assert dangerous_write_arg("xxd", ["xxd", "--", "-r"]) is None
+
+    def test_output_before_double_dash_still_detected(self):
+        assert dangerous_write_arg("sort", ["sort", "-o", "/etc/cron.d/x", "--", "foo"]) is not None
+
 
 class TestWriteViaArgSubstitution:
     """Blunt: any write-via-arg target inside a substitution is BLOCKED (#113)."""
@@ -118,3 +128,9 @@ class TestWriteViaArgTopLevel:
 
     def test_sort_output_to_root_ssh_is_high(self):
         assert validate_command("sort -o /root/.ssh/authorized_keys k").risk_level == RiskLevel.HIGH
+
+    def test_sort_output_to_braced_home_is_high(self):
+        assert validate_command('sort -o "${HOME}/.bashrc" in').risk_level == RiskLevel.HIGH
+
+    def test_sort_output_to_braced_home_ssh_is_high(self):
+        assert validate_command('sort -o "${HOME}/.ssh/authorized_keys" k').risk_level == RiskLevel.HIGH


### PR DESCRIPTION
## Summary
Closes #113. Two-layer fix for write-via-arg file writes, mirroring the find/#97 split (blunt substitution, target-aware top level):

- **Substitution (blunt):** new pure `dangerous_write_arg` helper wired into `_has_dangerous_inner_structure` — `sort -o` / `sdiff -o` / `xxd -r` writing files inside `$()`/`<()` are now **BLOCKED**. These are whitelisted and previously took the SAFE fast-path, bypassing YAML. Any write target is blocked (blunt); writing files inside a substitution is rare, so the FP cost is low and explicitly pinned by a test.
- **Top-level (target-aware):** new `write_via_arg_persistence` YAML rule flags `sort/sdiff -o` to **sensitive** paths (cron, shell-rc, authorized_keys, sudoers, /root, systemd, …) as **HIGH**; benign `sort -o out.txt` stays SAFE. Catches combined (`-ro`), attached (`-o/path`), quoted, and `--output=` forms; `[^;|&\\n]` prevents cross-command misattribution.
- `xxd -r` (code_obfuscation) and `tee` (truncation) are already flagged at top level; `tee` in substitution already BLOCKED — both regression-tested, not re-added.

## Test Plan
- [ ] `uv run pytest tests/test_write_via_arg.py` (31 tests: helper units, substitution behavior, top-level, FP guards, accepted-FP pin, tee regression)
- [ ] `sort -o out.txt` → SAFE; `sort -ro /etc/cron.d/x` → HIGH; `echo "\$(sort -o /etc/cron.d/x …)"` → BLOCKED
- [ ] Full suite green

## Follow-ups (not in this PR)
- Broader write-via-arg commands (cp/mv, gpg -o, openssl -out, awk, sed -i)
- Expand top-level sensitive-target list (/etc/hosts, /etc/fstab, ~/.config/systemd, /boot)