### PR TITLE
feat(rules): guard blanket git staging (git add -A/--all/-a/.) as HIGH (LAB-400)

### DIFF
--- a/data/rules/10_development_workflows.yaml
+++ b/data/rules/10_development_workflows.yaml
@@ -16,6 +16,17 @@ rules:
     patterns: ['git\s+reset\s+--hard']
     alternatives: ["Use git stash first"]
 
+  - name: git_blanket_staging
+    description: Blanket staging sweeps build artifacts, secrets, and unrelated edits into the index
+    risk_level: HIGH  # -> ask under balanced preset (MEDIUM would be a silent allow)
+    patterns:
+      - 'git\s+add\b[^;|&]{0,100}\s(--all|-A|-a)(\s|$)'
+      - 'git\s+add\b[^;|&]{0,100}\s\.(\s|$)'
+    alternatives:
+      - "Stage explicit paths: git add <path> ..."
+      - "Review first: git status --short"
+      - "Stage interactively: git add -p"
+
   - name: database_drop
     description: Dropping databases is irreversible
     risk_level: HIGH

--- a/data/rules/10_development_workflows.yaml
+++ b/data/rules/10_development_workflows.yaml
@@ -20,8 +20,9 @@ rules:
     description: Blanket staging sweeps build artifacts, secrets, and unrelated edits into the index
     risk_level: HIGH  # -> ask under balanced preset (MEDIUM would be a silent allow)
     patterns:
-      - 'git\s+add\b[^;|&]{0,100}\s(--all|-A|-a)(\s|$)'
-      - 'git\s+add\b[^;|&]{0,100}\s\.(\s|$)'
+      # Negative lookahead exempts interactive (-p/-i) and dry-run (-n) forms:
+      # patch mode confirms every hunk and can't stage untracked junk; dry runs mutate nothing
+      - 'git\s+add\b(?![^;|&]{0,100}\s(?:-p|-i|--patch|--interactive|-n|--dry-run)\b)[^;|&]{0,100}\s(--all|-A|-a|\.)(\s|$)'
     alternatives:
       - "Stage explicit paths: git add <path> ..."
       - "Review first: git status --short"

--- a/tests/test_pattern_coverage.py
+++ b/tests/test_pattern_coverage.py
@@ -283,10 +283,16 @@ class TestHighPatternCoverage:
             result = validate_command(cmd, config_path=safety_rules_path)
             assert result.risk_level == RiskLevel.HIGH, f"Blanket staging not HIGH: {cmd}"
 
-        # Should NOT mark as HIGH (explicit-path or interactive adds)
+        # Should NOT mark as HIGH (explicit-path, interactive, or dry-run adds)
         safe = [
             "git add src/foo.py",
             "git add -p",
+            "git add -p .",
+            "git add . --patch",
+            "git add -i .",
+            "git add -n .",
+            "git add --dry-run -A",
+            "git add ./",
             "git add .gitignore",
             "git add ../other/file.txt",
             "git add README.md docs/guide.md",

--- a/tests/test_pattern_coverage.py
+++ b/tests/test_pattern_coverage.py
@@ -263,6 +263,38 @@ class TestHighPatternCoverage:
             result = validate_command(cmd, config_path=safety_rules_path)
             assert result.risk_level != RiskLevel.HIGH, f"False positive on: {cmd}"
 
+    def test_git_blanket_staging_patterns(self, safety_rules_path):
+        """Test git_blanket_staging pattern matching (GH #116).
+
+        Blanket staging sweeps build artifacts and secrets into the index.
+        HIGH so the balanced preset prompts (MEDIUM would be a silent allow).
+        """
+        # Should mark as HIGH
+        dangerous = [
+            "git add -A",
+            "git add --all",
+            "git add -a",
+            "git add .",
+            "git add -A .",
+            "git add -v -A",
+            "git add . && git commit -m 'wip'",
+        ]
+        for cmd in dangerous:
+            result = validate_command(cmd, config_path=safety_rules_path)
+            assert result.risk_level == RiskLevel.HIGH, f"Blanket staging not HIGH: {cmd}"
+
+        # Should NOT mark as HIGH (explicit-path or interactive adds)
+        safe = [
+            "git add src/foo.py",
+            "git add -p",
+            "git add .gitignore",
+            "git add ../other/file.txt",
+            "git add README.md docs/guide.md",
+        ]
+        for cmd in safe:
+            result = validate_command(cmd, config_path=safety_rules_path)
+            assert result.risk_level != RiskLevel.HIGH, f"False positive on: {cmd}"
+
     def test_chmod_777_patterns(self, safety_rules_path):
         """Test chmod_777 pattern matching (including recursive)."""
         # Should mark as HIGH (chmod_777 rule)


### PR DESCRIPTION
LAB-400 · Closes #116

## What

New `git_blanket_staging` rule in `data/rules/10_development_workflows.yaml` (beside `git_force_push` / `git_hard_reset`) at `risk_level: HIGH` — the staging footgun that motivated the project finally has a rule.

## Why HIGH, not MEDIUM

`map_risk_to_status()` under the default `balanced` preset maps MEDIUM → silent allow. HIGH → `ask`, and composes across presets with no per-user edits: `permissive` → allow, `paranoid` → deny.

## Patterns

```yaml
- 'git\s+add\b[^;|&]{0,100}\s(--all|-A|-a)(\s|$)'
- 'git\s+add\b[^;|&]{0,100}\s\.(\s|$)'
```

Uses the file's existing `[^;|&]{0,100}` idiom (cf. `git_force_push`) instead of the simpler alternation proposed in #116, so interleaved flags (`git add -v -A`) match while the char class can't cross command separators. `\b` after `add` blocks prefix matches (`git addendum -A`); the trailing `(\s|$)` guard is the "trailing space or end-of-line" boundary from the acceptance criteria — `git add -An` (dry run) deliberately does not match.

**Matches (HIGH → ask under balanced):** `git add -A`, `git add --all`, `git add -a`, `git add .`, `git add -v -A`, `git add -A src/` (trailing space per spec; still sweeps junk under the path), `git add . && git commit -m 'wip'`

**Does not match:** `git add src/foo.py`, `git add -p`, `git add .gitignore`, `git add ../other/file.txt`, `git add -An`/`-Av` (combined flags), `git add -u`, `git add ./` (Tier 2 territory per the issue's non-goals)

## Tests

`test_git_blanket_staging_patterns` in `tests/test_pattern_coverage.py` following the `test_git_force_push_patterns` idiom — 7 blanket forms → HIGH, 5 explicit-path forms → not HIGH. Rule registers in the rule-coverage suite (`tests/rule_coverage.py` → ✅ `git_blanket_staging`).

Full suite: **1892 passed**. Two pre-existing failures (`test_high_risk_ask`, `test_high_command_asks`) reproduce on a clean checkout — they assert balanced-default mapping but this box's `~/.config/schlock/config.yaml` is `preset: permissive`; unrelated to this change (they read live user config, not the repo).

Non-goal (per issue): Tier 2 context-aware probe (`git status --porcelain` escalation) — needs a capability the validator doesn't have; file separately if wanted.
