### PR TITLE
LAB-405: feat(commit-filter): strip Multica agent co-author trailer

### DIFF
--- a/data/commit_filter_rules.yaml
+++ b/data/commit_filter_rules.yaml
@@ -30,8 +30,8 @@ rules:
         description: "Any line with robot emoji and 'Generated with'"
         replacement: "\n"
 
-      - pattern: "(?i)\\n*Co-Authored-By:.*(?:Claude|@anthropic\\.com).*\\n*"
-        description: "Any Co-Authored-By line mentioning Claude or Anthropic"
+      - pattern: "(?i)\\n*Co-Authored-By:.*(?:Claude|@anthropic\\.com|@multica\\.ai).*\\n*"
+        description: "Any Co-Authored-By line mentioning Claude, Anthropic, or Multica"
         replacement: "\n"
 
       # Specific patterns (catch remnants the broad patterns might miss)

--- a/tests/test_commit_filter.py
+++ b/tests/test_commit_filter.py
@@ -1599,6 +1599,61 @@ class TestPatternCaseWhitespace:
         assert not patterns  # lowercase 'secret' must NOT match the case-sensitive custom pattern
 
 
+class TestMulticaAttribution:
+    """LAB-405: strip the Multica agent co-author trailer (adspam) exactly like the
+    Claude/Anthropic one, while preserving functional `Multica: LAB-xxx` annotations
+    that drive PR auto-linking. Tests run against the REAL bundled rules."""
+
+    @staticmethod
+    def _filter():
+        return CommitMessageFilter(load_filter_config())
+
+    def _result(self, body):
+        cmd = f'git commit -m "feat: x\\n\\n{body}"'
+        return self._filter().filter_commit_message(cmd)
+
+    def test_reference_trailer_stripped(self):
+        # Exact casing/shape verified against cachekit-io/cachekit-py#218.
+        result = self._result("Co-authored-by: multica-agent <github@multica.ai>")
+        assert result.was_modified
+        assert "multica" not in result.cleaned_message.lower()
+
+    def test_uppercase_trailer_stripped(self):
+        result = self._result("Co-Authored-By: Multica-Agent <GitHub@Multica.AI>")
+        assert result.was_modified
+        assert "multica" not in result.cleaned_message.lower()
+
+    def test_whitespace_tolerant_trailer_stripped(self):
+        result = self._result("co-authored-by:   multica-agent   <github@multica.ai>")
+        assert result.was_modified
+        assert "multica" not in result.cleaned_message.lower()
+
+    def test_sidebar_annotation_preserved(self):
+        # `· Multica: LAB-xxx` is the functional PR auto-link identifier — NEVER strip it.
+        result = self._result("Closes #170 · Multica: LAB-108")
+        assert not result.patterns_removed
+        assert not result.was_modified
+
+    def test_bare_sidebar_annotation_preserved(self):
+        result = self._result("Multica: LAB-108")
+        assert not result.patterns_removed
+        assert not result.was_modified
+
+    def test_prose_mention_not_stripped(self):
+        # No over-strip: only the co-author trailer shape matches, not the word itself.
+        result = self._result("Document the multica CLI and Multica workspace setup")
+        assert not result.patterns_removed
+        assert not result.was_modified
+
+    def test_trailer_stripped_but_annotation_survives_in_same_message(self):
+        # The two can coexist in one body: adspam goes, the sidebar identifier stays.
+        body = "Closes #170 · Multica: LAB-108\\n\\nCo-authored-by: multica-agent <github@multica.ai>"
+        result = self._result(body)
+        assert result.was_modified
+        assert "Co-authored-by" not in result.cleaned_message
+        assert "Multica: LAB-108" in result.cleaned_message
+
+
 class TestParseMemoization:
     """#91 — bashlex.parse must run at most once per command per filter call."""
 


### PR DESCRIPTION
Closes LAB-405

## What

Broadens the commit ad-blocker's `advertising` category to strip the Multica agent co-author trailer (`Co-authored-by: multica-agent <github@multica.ai>`) the same way the Claude/Anthropic one already is — while explicitly preserving functional `Multica: LAB-xxx` annotations that drive Multica's PR sidebar auto-linking.

## How

One-line YAML change: the broad line-level pattern's alternation gains `@multica\.ai`:

```
(?i)\n*Co-Authored-By:.*(?:Claude|@anthropic\.com|@multica\.ai).*\n*
```

Anchoring on the trailer shape (not the bare word "Multica") makes the preserve requirement structurally free — a `Multica: LAB-108` body line is not a co-author line, so it can never match. No carve-out logic needed; the guarantee is enforced by guard tests.

## Tests

New `TestMulticaAttribution` class (7 tests) running against the **real bundled rules** (`load_filter_config()`), so they fail if the YAML edit regresses:

- strip: exact reference trailer from cachekit-io/cachekit-py#218, uppercase variant, extra-whitespace variant
- preserve: `· Multica: LAB-108` and bare `Multica: LAB-108` untouched
- no over-strip: prose mentioning "multica"/"Multica" untouched
- coexistence: trailer stripped while the `Multica: LAB-108` line in the same body survives

`tests/test_commit_filter.py`: 191 passed. Ruff lint + format: clean.

Note: `test_hook_integration.py::TestStatusMapping::test_high_risk_ask` fails on clean main too — it assumes the default `balanced` preset but reads local user config (`permissive` here). Pre-existing, environment-dependent, untouched by this PR.

## Out of scope (per ticket)

- No "Generated with Multica" pattern — no such footer exists in the reference PR.
- The `-F`/`$(...)`/PR-body content gap (#76/#86/#79) is inherited, not closed; `unscannable_message_action` already governs it.

Amusing side note: the installed schlock hook blocked this PR's own first commit attempt because the message quoted the literal trailer text — the filter works.


BEGIN_COMMIT_OVERRIDE
feat(commit-filter): strip Multica agent co-author trailer (LAB-405)
END_COMMIT_OVERRIDE
