### PR TITLE
feat(hooks): detect post-commit advertising slippage via PostToolUse (LAB-668)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ pre-commit install
 uv run ruff format .
 ```
 
-**Note**: schlock's built-in formatter feature is **non-functional** because Claude Code does not support PostToolUse hooks for plugins. Use standard pre-commit hooks for code formatting.
+**Note**: schlock's built-in formatter feature is **not implemented**. Earlier docs claimed Claude Code doesn't support PostToolUse hooks for plugins — that is stale: verified on Claude Code v2.1.214 (2026-07) that a plugin `hooks/hooks.json` registers `PostToolUse` fine (schlock's post-commit advertising detector uses it). The formatter is now revivable but remains unbuilt; use standard pre-commit hooks for code formatting.
 
 ### Python Style
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ commit_filter:
       enabled: true
 ```
 
+Two layers: a **pre-execution** filter blocks advertising visible in the command string, and a
+**post-commit** detector catches messages delivered from outside the command (`-F <file>`,
+stdin/heredocs, `$(cat file)`) by scanning the actual committed message and prompting an amend —
+it never rewrites history itself.
+
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for advanced options and team-wide settings.
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 This document describes how to configure schlock features, customize safety rules, and integrate with your development workflow.
 
-> **⚠️ Note on Code Formatting**: The `formatter` configuration options documented below are **non-functional** because Claude Code does not support PostToolUse hooks for plugins. For code formatting, use [pre-commit hooks](https://pre-commit.com/) (industry standard).
+> **⚠️ Note on Code Formatting**: The `formatter` configuration options documented below are **not implemented**. (Earlier versions of this note claimed Claude Code doesn't support PostToolUse hooks for plugins — that is stale; plugin `PostToolUse` registration works as of Claude Code v2.1.214 and schlock's post-commit advertising detector relies on it.) For code formatting, use [pre-commit hooks](https://pre-commit.com/) (industry standard).
 
 ## Table of Contents
 
@@ -280,7 +280,32 @@ unscannable_message_action: warn   # off | warn | block  (default: warn)
 > **What `warn`/`block` can and cannot do.** This is a *pre-execution* heads-up: it cannot
 > read the file or stdin content, so it cannot confirm a trailer is present — only that the
 > message could not be scanned. The reliable place to catch a trailer that actually landed is
-> *after* the commit exists; detecting post-commit slippage is tracked separately.
+> *after* the commit exists — that is the post-commit slippage detector below.
+
+### Post-Commit Slippage Detection (PostToolUse)
+
+A `PostToolUse` hook (`hooks/post_tool_use.py`) closes the gap above durably. After any Bash
+command mentioning `git` + `commit`, it reads the **actual committed message** from the commit
+object (`git log -1 --format=%B`) and runs the same advertising patterns over it. Because the
+message has materialized by then, one detector covers *every* delivery form — `-F <file>`,
+`--file=`, stdin/heredoc, and `$(cat file)` substitution — with no file-content reading and
+none of the TOCTOU/symlink risks that ruled out scanning the `-F` target pre-execution.
+
+On detection it **never rewrites history**: it injects feedback (`additionalContext`) naming
+the offending content and instructing the model to `git commit --amend` it away (and to leave
+already-pushed commits alone). The amend re-fires the hook; a clean message produces silence,
+terminating the loop.
+
+Guard rails:
+
+- **Freshness gate**: the Bash tool "succeeds" even when `git commit` was a no-op, so only a
+  HEAD committed within the last 30 seconds is inspected — a failed re-run cannot re-flag an
+  old commit.
+- **Fail-open + cheap-gated**: errors and non-repo directories are silent; the hook does no
+  real work unless the command looks like a commit. Disabling the commit filter
+  (`enabled: false`) disables this detector too.
+- **Known limit**: the message is read from the session's working directory, so a commit made
+  in a *different* repo (`git -C /elsewhere commit`) is not inspected.
 
 ### Why Block Instead of Filter?
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@ This roadmap outlines schlock's evolution. Priorities are driven by user feedbac
 **Known Limitations**:
 - **No per-rule overrides**: Can't customize individual rule severity
 - **No code quality rules**: Only security-focused rules exist
-- **Code formatter**: Non-functional (Claude Code doesn't support PostToolUse hooks)
+- **Code formatter**: Not implemented (the old "Claude Code doesn't support PostToolUse hooks for plugins" blocker is gone — verified working on v2.1.214 — so this is revivable if demand appears)
 
 ---
 
@@ -137,7 +137,7 @@ Default risk level: **HIGH** (prompts in balanced mode, users can override to BL
 
 | Feature | Reason |
 |---------|--------|
-| Code formatter | Claude Code doesn't support PostToolUse hooks |
+| Code formatter | No demand; former PostToolUse-for-plugins blocker is gone (verified on v2.1.214), revivable if demand appears |
 | Telemetry | Privacy concerns, unclear value |
 | Web dashboard | CLI-first is sufficient |
 | PyPI package | No demand signal yet |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,6 +21,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/post_tool_use.py"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/hooks/post_tool_use.py
+++ b/hooks/post_tool_use.py
@@ -13,8 +13,9 @@ Behavior:
   `hookSpecificOutput.additionalContext` instructing the model to `git commit --amend`.
 - Fail-open: any error, missing git, non-repo cwd, or stale HEAD -> silent exit 0.
   This is a cosmetic filter, not a security boundary.
-- Cheap-gated: substring check on the command before any subprocess or heavy import
-  (the hook runs on every Bash call; latency is load-bearing).
+- Cheap-gated: substring check on the command first (the hook runs on every Bash call;
+  latency is load-bearing), then the PreToolUse filter's bashlex-backed recognizer binds
+  to real `git … commit` invocations before any subprocess runs.
 - Freshness-gated: the Bash tool "succeeds" even when `git commit` exits non-zero, so
   only a HEAD committed within FRESHNESS_WINDOW_SECONDS is inspected — a failed re-run
   must not re-flag a stale commit.
@@ -125,10 +126,29 @@ def handle_post_tool_use(input_data: dict) -> Optional[dict]:  # noqa: PLR0911 -
 
     command = input_data.get("tool_input", {}).get("command", "")
     # Cheap gate: cost is on every Bash call. Substrings (not "git commit" literal) so
-    # global-option forms like `git -C <path> commit` still pass. Precision comes free
-    # from the freshness gate + the fact that we scan HEAD's actual message: a false
-    # pass here costs one git subprocess and can never mis-flag a clean commit.
+    # global-option forms like `git -C <path> commit` still reach the precise recognizer.
     if "git" not in command or "commit" not in command:
+        return None
+
+    # Heavy imports only after the cheap gate passed.
+    try:
+        from schlock.integrations.commit_filter import CommitMessageFilter, load_filter_config  # noqa: PLC0415 - lazy
+
+        config = load_filter_config()
+        commit_filter = CommitMessageFilter(config)
+        if not commit_filter.enabled:
+            return None
+        # Precision gate: the same bashlex-backed recognizer the PreToolUse filter uses.
+        # Rejects text mentions (`echo "git commit"`) and binds to real commit invocations.
+        if not commit_filter.is_git_commit_command(command):
+            return None
+        # A commit redirected to another repository (git -C <path> / --git-dir / --work-tree)
+        # cannot be judged by THIS directory's HEAD — skip rather than flag the wrong commit.
+        # (Documented limit: such commits are not inspected.)
+        if commit_filter.commit_targets_external_repo(command):
+            return None
+    except Exception as e:
+        logger.warning(f"Post-commit filter failed: {e}. Skipping (fail-open).")
         return None
 
     head = read_head_commit(input_data.get("cwd"))
@@ -141,14 +161,7 @@ def handle_post_tool_use(input_data: dict) -> Optional[dict]:  # noqa: PLR0911 -
     if time.time() - committed_at > FRESHNESS_WINDOW_SECONDS:
         return None
 
-    # Heavy imports only after all cheap gates passed.
     try:
-        from schlock.integrations.commit_filter import CommitMessageFilter, load_filter_config  # noqa: PLC0415 - lazy
-
-        config = load_filter_config()
-        commit_filter = CommitMessageFilter(config)
-        if not commit_filter.enabled:
-            return None
         _cleaned, patterns_removed, categories = commit_filter.clean_message(message)
     except Exception as e:
         logger.warning(f"Post-commit filter failed: {e}. Skipping (fail-open).")

--- a/hooks/post_tool_use.py
+++ b/hooks/post_tool_use.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: detect advertising that slipped into the actual committed message.
+
+The PreToolUse commit filter can only scan argv. Messages delivered from outside argv
+(`git commit -F <file>`, `-F -`/heredoc stdin, `-m "$(cat file)"`) materialize at exec
+time, so a trailer can land on a real commit despite the pre-execution filter (issue #79,
+refs #76, complements #78). Post-execution the byte-location problem vanishes: this hook
+reads the message from the commit object itself (`git log -1`), so one detector covers
+every delivery form.
+
+Behavior:
+- Detect-and-feedback ONLY. Never rewrites history (no auto-amend) — it injects
+  `hookSpecificOutput.additionalContext` instructing the model to `git commit --amend`.
+- Fail-open: any error, missing git, non-repo cwd, or stale HEAD -> silent exit 0.
+  This is a cosmetic filter, not a security boundary.
+- Cheap-gated: substring check on the command before any subprocess or heavy import
+  (the hook runs on every Bash call; latency is load-bearing).
+- Freshness-gated: the Bash tool "succeeds" even when `git commit` exits non-zero, so
+  only a HEAD committed within FRESHNESS_WINDOW_SECONDS is inspected — a failed re-run
+  must not re-flag a stale commit.
+- Self-terminating: the amend re-fires this hook; a clean amended message produces no
+  output, ending the loop. A pathological re-add of the trailer re-flags — that is the
+  correct response, and since the hook only ever informs (never blocks), no state is
+  needed to bound it.
+
+Hook Interface:
+- Input: JSON via stdin (tool_input.command, cwd, ...)
+- Output: JSON with hookSpecificOutput.additionalContext on detection; nothing otherwise
+"""
+
+import json
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+# Add vendored dependencies to path FIRST (pure Python packages)
+vendor_path = Path(__file__).parent.parent / ".claude-plugin" / "vendor"
+if vendor_path.exists():
+    sys.path.insert(0, str(vendor_path))
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+logging.basicConfig(level=logging.INFO, format="[schlock-post-hook] %(levelname)s: %(message)s", stream=sys.stderr)
+logger = logging.getLogger(__name__)
+
+# Only inspect a HEAD committed within this window. Wide enough for compound commands
+# (`git commit -F f && make test`) where the hook fires after the whole command; narrow
+# enough that a later failed/no-op `git commit` doesn't re-flag an old HEAD.
+FRESHNESS_WINDOW_SECONDS = 30
+
+# Timeout for the single git subprocess (seconds).
+GIT_TIMEOUT_SECONDS = 5
+
+
+def read_head_commit(cwd: Optional[str]) -> Optional[tuple[int, str, str]]:
+    """Read HEAD's committer timestamp, short hash, and full message.
+
+    Returns:
+        (committer_epoch, short_hash, message) or None if cwd is not a git repo,
+        the repo has no commits, or git is unavailable (fail-open).
+
+    Reads `git log`, not an attacker-supplied path — none of the TOCTOU/symlink/FIFO
+    risks that ruled out reading the `-F` target pre-execution apply here.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ct %h%n%B"],
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+            cwd=cwd or None,
+        )
+        if result.returncode != 0:
+            return None
+        first_line, _, message = result.stdout.partition("\n")
+        epoch_str, _, short_hash = first_line.partition(" ")
+        return int(epoch_str), short_hash, message
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def format_amend_prompt(short_hash: str, patterns_removed: list[dict]) -> str:
+    """Build the additionalContext message instructing the model to amend."""
+    offending = "\n".join(f"  - {p.get('description', p.get('pattern', 'advertising pattern'))}" for p in patterns_removed)
+    return (
+        f"schlock: advertising content landed in commit {short_hash} — the message was delivered "
+        f"outside argv (e.g. -F/--file, stdin, or command substitution), so the pre-execution "
+        f"filter could not scan it.\n\n"
+        f"Offending content:\n{offending}\n\n"
+        f"Fix it now: rewrite the message with `git commit --amend`, keeping the real message and "
+        f"removing ONLY the advertising lines above. Do NOT amend if this commit has already been "
+        f"pushed to a shared branch — in that case, tell the user instead of rewriting history."
+    )
+
+
+def audit_detection(command: str, categories: list[str], cwd: Optional[str], start_time: float) -> None:
+    """Record the post-commit detection in the audit log (best-effort, never raises)."""
+    try:
+        from schlock.integrations.audit import AuditContext, get_audit_logger  # noqa: PLC0415 - lazy, post-gate
+
+        get_audit_logger().log_validation(
+            command=command[:500],
+            risk_level="LOW",
+            violations=[f"commit_filter: post-commit advertising detected ({cat})" for cat in categories],
+            decision="warn",
+            execution_time_ms=(time.perf_counter() - start_time) * 1000,
+            context=AuditContext(project_root=cwd or "", current_dir=cwd or "", environment="development"),
+        )
+    except Exception as e:
+        logger.warning(f"Audit logging failed: {e}")
+
+
+def handle_post_tool_use(input_data: dict) -> Optional[dict]:  # noqa: PLR0911 - guard-clause gates require multiple exits
+    """Inspect HEAD after a git-commit-shaped Bash command; flag advertising in its message.
+
+    Returns:
+        Hook response dict with additionalContext on detection, None for silence.
+    """
+    start_time = time.perf_counter()
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    # Cheap gate: cost is on every Bash call. Substrings (not "git commit" literal) so
+    # global-option forms like `git -C <path> commit` still pass. Precision comes free
+    # from the freshness gate + the fact that we scan HEAD's actual message: a false
+    # pass here costs one git subprocess and can never mis-flag a clean commit.
+    if "git" not in command or "commit" not in command:
+        return None
+
+    head = read_head_commit(input_data.get("cwd"))
+    if head is None:
+        return None
+    committed_at, short_hash, message = head
+
+    # Freshness gate: Bash "succeeds" even when `git commit` was a no-op (nothing staged,
+    # hook failure, --dry-run). Only a just-created HEAD is attributable to this command.
+    if time.time() - committed_at > FRESHNESS_WINDOW_SECONDS:
+        return None
+
+    # Heavy imports only after all cheap gates passed.
+    try:
+        from schlock.integrations.commit_filter import CommitMessageFilter, load_filter_config  # noqa: PLC0415 - lazy
+
+        config = load_filter_config()
+        commit_filter = CommitMessageFilter(config)
+        if not commit_filter.enabled:
+            return None
+        _cleaned, patterns_removed, categories = commit_filter.clean_message(message)
+    except Exception as e:
+        logger.warning(f"Post-commit filter failed: {e}. Skipping (fail-open).")
+        return None
+
+    if not patterns_removed:
+        # Clean message — also the amend-loop terminator: a successful amend lands here.
+        return None
+
+    logger.warning(f"[commit-filter] post-commit advertising detected in {short_hash} (categories: {', '.join(categories)})")
+    audit_detection(command, categories, input_data.get("cwd"), start_time)
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": format_amend_prompt(short_hash, patterns_removed),
+        }
+    }
+
+
+def main():
+    """Entry point for Claude Code hook execution. Always exits 0 (fail-open)."""
+    try:
+        input_data = json.load(sys.stdin)
+        result = handle_post_tool_use(input_data)
+        if result is not None:
+            print(json.dumps(result))
+    except Exception as e:
+        # Cosmetic detector: never surface an error into the session (exit 2 would feed
+        # stderr to the model). Log and stay silent.
+        logger.error(f"Fatal error in post_tool_use hook: {e}", exc_info=True)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/schlock/core/rules.py
+++ b/src/schlock/core/rules.py
@@ -227,7 +227,7 @@ class RuleEngine:
         engine.rules = []
         engine.compiled_patterns = {}
         engine.whitelist_patterns = []
-        engine._original_risk_levels: dict[str, RiskLevel] = {}
+        engine._original_risk_levels = {}
 
         # Load rules from all YAML files in directory
         engine._load_rules_from_directory(rules_dir)

--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -912,6 +912,17 @@ class CommitMessageFilter:
                 )
 
             # delivery == "scannable": by the classifier contract `message` is non-None here.
+            # Guard anyway - this method never raises (fail-open contract), and the check
+            # narrows the type for static analysis.
+            if message is None:
+                return FilterResult(
+                    cleaned_command=command,
+                    original_message="",
+                    cleaned_message="",
+                    was_modified=False,
+                    message_delivery="scannable",
+                    error="internal: scannable delivery but no message extracted",
+                )
 
             # Clean message
             cleaned, patterns_removed, categories = self.clean_message(message)

--- a/src/schlock/integrations/commit_filter.py
+++ b/src/schlock/integrations/commit_filter.py
@@ -261,6 +261,50 @@ class CommitMessageFilter:
         except Exception:  # noqa: BLE001 - bashlex raises various types; fail-open to regex
             return bool(re.search(r"\bgit\b.*?\bcommit\b", command, re.DOTALL))
 
+    # Git global options that redirect which repository a commit lands in. A `git log` run in
+    # the process working directory says nothing about such a commit, so the post-commit
+    # detector must skip these rather than judge the wrong repo's HEAD (issue #79 review).
+    _GIT_REPO_TARGET_OPTS = frozenset({"-C", "--git-dir", "--work-tree"})
+
+    def commit_targets_external_repo(self, command: str) -> bool:
+        """True when every ``git … commit`` invocation redirects its target repository via a
+        global ``-C`` / ``--git-dir`` / ``--work-tree`` option — i.e. the repo in the current
+        working directory is NOT the one committed to.
+
+        Fail-open toward False (= inspect cwd): oversized or unparseable commands are treated
+        as targeting cwd, matching is_git_commit_command's over-detection bias. Downstream
+        freshness + message gates make over-inspection harmless.
+        """
+        if len(command) > MAX_COMMAND_SIZE:
+            return False
+        invocations_external: list[bool] = []
+
+        def visit(node: Any) -> None:
+            if getattr(node, "kind", None) == "command":
+                words = [p.word for p in getattr(node, "parts", []) if hasattr(p, "word")]
+                idx = self._commit_subcommand_index(words)
+                if idx != -1:
+                    globals_before = words[1:idx]
+                    invocations_external.append(
+                        any(
+                            w in self._GIT_REPO_TARGET_OPTS or w.startswith(("--git-dir=", "--work-tree="))
+                            for w in globals_before
+                        )
+                    )
+            for attr in ("parts", "list", "command"):
+                child = getattr(node, attr, None)
+                if child is None:
+                    continue
+                for item in child if isinstance(child, list) else [child]:
+                    visit(item)
+
+        try:
+            for part in self._parse(command):
+                visit(part)
+        except Exception:  # noqa: BLE001 - bashlex raises various types; fail toward inspecting
+            return False
+        return bool(invocations_external) and all(invocations_external)
+
     def extract_commit_message(self, command: str) -> Optional[str]:
         """Extract commit message from git command using dual-mode parsing.
 

--- a/tests/test_post_tool_use.py
+++ b/tests/test_post_tool_use.py
@@ -150,6 +150,13 @@ class TestNoFalsePositives:
         monkeypatch.setattr(post_tool_use.subprocess, "run", boom)
         assert handle_post_tool_use(hook_input("echo hello", git_repo)) is None
 
+    def test_text_mention_of_git_commit_is_silent(self, git_repo):
+        """`echo "git commit"` is not a commit invocation — even with a fresh dirty HEAD."""
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        run_bash("git commit -F msg.txt", git_repo)  # fresh trailer-bearing HEAD in cwd
+
+        assert handle_post_tool_use(hook_input('echo "git commit"', git_repo)) is None
+
     def test_non_repo_cwd_is_silent(self, tmp_path):
         assert handle_post_tool_use(hook_input("git commit -m x", tmp_path)) is None
 
@@ -188,9 +195,82 @@ class TestGitGlobalOptionForms:
 
         assert handle_post_tool_use(hook_input(command, git_repo)) is not None
 
+    def test_git_dash_upper_c_external_repo_is_not_inspected(self, git_repo, tmp_path):
+        """`git -C <other-repo> commit` commits elsewhere — cwd's HEAD says nothing about it.
+
+        The hook must stay silent (documented limit: external targets are not inspected),
+        NOT judge the session cwd's repository.
+        """
+        env = git_env()
+        other = tmp_path / "other-repo"
+        other.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=other, env=env, check=True)
+        (other / "f.txt").write_text("x\n")
+        subprocess.run(["git", "-C", str(other), "add", "f.txt"], env=env, check=True)
+        (other / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+
+        command = f"git -C {other} commit -F {other / 'msg.txt'}"
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        assert handle_post_tool_use(hook_input(command, git_repo)) is None
+
+    def test_external_repo_commit_never_flags_cwd_head(self, git_repo, tmp_path):
+        """A fresh trailer-bearing HEAD in cwd must NOT be blamed on a `git -C` command
+        that committed to a different repository (the wrong-commit amend-prompt hazard)."""
+        # Fresh trailer commit in cwd (was flagged by its own hook run when it happened).
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        run_bash("git commit -F msg.txt", git_repo)
+
+        env = git_env()
+        other = tmp_path / "other-repo"
+        other.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=other, env=env, check=True)
+        (other / "f.txt").write_text("x\n")
+        subprocess.run(["git", "-C", str(other), "add", "f.txt"], env=env, check=True)
+
+        command = f'git -C {other} commit -m "clean elsewhere"'
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        assert handle_post_tool_use(hook_input(command, git_repo)) is None
+
+    def test_mixed_chain_with_cwd_commit_is_still_inspected(self, git_repo, tmp_path):
+        """External skip applies only when EVERY commit invocation is redirected."""
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        command = f"git -C {tmp_path} status; git commit -F msg.txt"
+        run_bash("git commit -F msg.txt", git_repo)
+
+        assert handle_post_tool_use(hook_input(command, git_repo)) is not None
+
 
 class TestHelpers:
     def test_read_head_commit_returns_none_outside_repo(self, tmp_path):
+        assert read_head_commit(str(tmp_path)) is None
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            OSError("git binary missing"),
+            subprocess.TimeoutExpired(cmd="git log", timeout=5),
+        ],
+        ids=["oserror", "timeout"],
+    )
+    def test_read_head_commit_fails_open_on_subprocess_errors(self, tmp_path, monkeypatch, exc):
+        def raise_exc(*args, **kwargs):
+            raise exc
+
+        monkeypatch.setattr(post_tool_use.subprocess, "run", raise_exc)
+        assert read_head_commit(str(tmp_path)) is None
+
+    def test_read_head_commit_fails_open_on_garbage_output(self, tmp_path, monkeypatch):
+        """Unparseable timestamp (ValueError path) must not raise."""
+
+        class Fake:
+            returncode = 0
+            stdout = "not-a-timestamp abc123\nmessage\n"
+
+        monkeypatch.setattr(post_tool_use.subprocess, "run", lambda *a, **k: Fake())
         assert read_head_commit(str(tmp_path)) is None
 
     def test_read_head_commit_parses_head(self, git_repo):

--- a/tests/test_post_tool_use.py
+++ b/tests/test_post_tool_use.py
@@ -1,0 +1,219 @@
+"""Tests for the PostToolUse post-commit advertising detector (issue #79).
+
+Every bypass form is exercised against a REAL git repo: the whole point of the
+PostToolUse detector is that byte-location no longer matters once the message has
+materialized into the commit object, so the tests commit through the same delivery
+channels that evade the PreToolUse filter (-F file, stdin heredoc, $(cat file)) and
+assert on what the hook sees in `git log`.
+"""
+
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+# Add src and hooks to path BEFORE importing (same pattern as test_hook_integration.py)
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import post_tool_use
+from post_tool_use import handle_post_tool_use, read_head_commit
+
+TRAILER = "Co-Authored-By: Claude <noreply@anthropic.com>"
+CLEAN_MESSAGE = "feat: add the flux capacitor"
+
+
+def git_env() -> dict:
+    """Environment isolating tmp repos from the user's global git config/hooks/templates."""
+    env = os.environ.copy()
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    env["GIT_AUTHOR_NAME"] = env["GIT_COMMITTER_NAME"] = "Test"
+    env["GIT_AUTHOR_EMAIL"] = env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+    return env
+
+
+def run_bash(command: str, cwd: Path, env: Optional[dict] = None) -> subprocess.CompletedProcess:
+    """Run a command through bash, like the Bash tool does (heredocs, substitution)."""
+    return subprocess.run(
+        ["bash", "-c", command],
+        cwd=cwd,
+        env=env or git_env(),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """Fresh git repo with one staged file, ready to commit."""
+    env = git_env()
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, env=env, check=True)
+    (tmp_path / "file.txt").write_text("content\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=tmp_path, env=env, check=True)
+    return tmp_path
+
+
+def hook_input(command: str, cwd: Path) -> dict:
+    """Minimal PostToolUse input payload as captured from a live Claude Code session."""
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {"stdout": "", "stderr": "", "interrupted": False},
+        "cwd": str(cwd),
+    }
+
+
+class TestBypassFormsAreDetected:
+    """The three outside-argv delivery forms the PreToolUse filter cannot scan."""
+
+    def test_trailer_via_dash_f_file(self, git_repo):
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        command = "git commit -F msg.txt"
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        response = handle_post_tool_use(hook_input(command, git_repo))
+
+        assert response is not None
+        context = response["hookSpecificOutput"]["additionalContext"]
+        assert response["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        assert "Co-Authored-By" in context
+        assert "git commit --amend" in context
+
+    def test_trailer_via_stdin_heredoc(self, git_repo):
+        command = f"git commit -F - <<'EOF'\n{CLEAN_MESSAGE}\n\n{TRAILER}\nEOF"
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        response = handle_post_tool_use(hook_input(command, git_repo))
+
+        assert response is not None
+        assert "git commit --amend" in response["hookSpecificOutput"]["additionalContext"]
+
+    def test_trailer_via_command_substitution(self, git_repo):
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        command = 'git commit -m "$(cat msg.txt)"'
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        response = handle_post_tool_use(hook_input(command, git_repo))
+
+        assert response is not None
+        assert "git commit --amend" in response["hookSpecificOutput"]["additionalContext"]
+
+    def test_detection_names_the_commit_hash(self, git_repo):
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        run_bash("git commit -F msg.txt", git_repo)
+        short_hash = run_bash("git rev-parse --short HEAD", git_repo).stdout.strip()
+
+        response = handle_post_tool_use(hook_input("git commit -F msg.txt", git_repo))
+
+        assert short_hash in response["hookSpecificOutput"]["additionalContext"]
+
+
+class TestNoFalsePositives:
+    def test_clean_commit_is_silent(self, git_repo):
+        command = f'git commit -m "{CLEAN_MESSAGE}"'
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        assert handle_post_tool_use(hook_input(command, git_repo)) is None
+
+    def test_failed_commit_does_not_reflag_stale_head(self, git_repo):
+        # Land a trailer-bearing commit with a committer date well outside the window...
+        env = git_env()
+        env["GIT_COMMITTER_DATE"] = "2020-01-01T00:00:00 +0000"
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        assert run_bash("git commit -F msg.txt", git_repo, env=env).returncode == 0
+
+        # ...then a no-op `git commit` (nothing staged) that the Bash tool still "succeeds" on.
+        command = 'git commit -m "nothing staged"'
+        result = run_bash(command, git_repo)
+        assert result.returncode != 0  # the commit itself failed
+
+        assert handle_post_tool_use(hook_input(command, git_repo)) is None
+
+    def test_non_git_command_exits_at_cheap_gate(self, git_repo, monkeypatch):
+        def boom(*args, **kwargs):
+            raise AssertionError("cheap gate must prevent any subprocess")
+
+        monkeypatch.setattr(post_tool_use.subprocess, "run", boom)
+        assert handle_post_tool_use(hook_input("echo hello", git_repo)) is None
+
+    def test_non_repo_cwd_is_silent(self, tmp_path):
+        assert handle_post_tool_use(hook_input("git commit -m x", tmp_path)) is None
+
+    def test_missing_command_is_silent(self, git_repo):
+        assert handle_post_tool_use({"tool_input": {}, "cwd": str(git_repo)}) is None
+
+
+class TestAmendLoopTerminates:
+    def test_clean_amend_produces_silence(self, git_repo):
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        run_bash("git commit -F msg.txt", git_repo)
+        assert handle_post_tool_use(hook_input("git commit -F msg.txt", git_repo)) is not None
+
+        # The remediation the hook asks for — re-fires the hook, must self-terminate.
+        amend = f'git commit --amend -m "{CLEAN_MESSAGE}"'
+        assert run_bash(amend, git_repo).returncode == 0
+        assert handle_post_tool_use(hook_input(amend, git_repo)) is None
+
+    def test_pathological_readd_is_reflagged(self, git_repo):
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        run_bash("git commit -F msg.txt", git_repo)
+
+        # Amend that re-adds the trailer via another outside-argv form: still flagged.
+        amend = f"git commit --amend -F - <<'EOF'\n{CLEAN_MESSAGE}\n\n{TRAILER}\nEOF"
+        assert run_bash(amend, git_repo).returncode == 0
+        assert handle_post_tool_use(hook_input(amend, git_repo)) is not None
+
+
+class TestGitGlobalOptionForms:
+    def test_git_dash_c_before_subcommand_still_gates_in(self, git_repo):
+        """`git -c foo=bar commit` has no literal "git commit" substring — must still detect."""
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        command = "git -c core.pager=cat commit -F msg.txt"
+        result = run_bash(command, git_repo)
+        assert result.returncode == 0, result.stderr
+
+        assert handle_post_tool_use(hook_input(command, git_repo)) is not None
+
+
+class TestHelpers:
+    def test_read_head_commit_returns_none_outside_repo(self, tmp_path):
+        assert read_head_commit(str(tmp_path)) is None
+
+    def test_read_head_commit_parses_head(self, git_repo):
+        run_bash(f'git commit -m "{CLEAN_MESSAGE}"', git_repo)
+        epoch, short_hash, message = read_head_commit(str(git_repo))
+        assert abs(time.time() - epoch) < 60
+        assert len(short_hash) >= 7
+        assert message.strip() == CLEAN_MESSAGE
+
+    def test_main_emits_json_on_detection_and_exits_zero(self, git_repo, monkeypatch, capsys):
+        (git_repo / "msg.txt").write_text(f"{CLEAN_MESSAGE}\n\n{TRAILER}\n")
+        run_bash("git commit -F msg.txt", git_repo)
+
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(hook_input("git commit -F msg.txt", git_repo))))
+        with pytest.raises(SystemExit) as exc:
+            post_tool_use.main()
+        assert exc.value.code == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert "additionalContext" in parsed["hookSpecificOutput"]
+
+    def test_main_is_silent_and_exits_zero_on_garbage_stdin(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+        with pytest.raises(SystemExit) as exc:
+            post_tool_use.main()
+        assert exc.value.code == 0
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
Closes #79. Refs #76; complements the merged #78 (pre-execution warn/block for the same command shapes).

## What

A `PostToolUse` hook (`hooks/post_tool_use.py`) that detects advertising trailers on the **actual committed message** — closing the `-F`/`--file`, stdin/heredoc, and `$(cat file)` substitution bypasses in one stroke. Post-execution, byte-location no longer matters: the hook reads `git log -1 --format=%B` (never an attacker-supplied path, so none of the TOCTOU/symlink/FIFO risks that ruled out reading the `-F` target pre-execution) and runs the **existing** `clean_message` antispam patterns. No new pattern engine.

On detection it injects `hookSpecificOutput.additionalContext` naming the offending content and instructing a `git commit --amend` (with an explicit warning not to amend already-pushed commits). It **never rewrites history** itself.

## Capability spike result (acceptance blocker)

**Plugins CAN register `PostToolUse`.** Verified on Claude Code v2.1.214 two ways:

1. Scratch plugin via `--plugin-dir` with a PostToolUse hook that dumps its stdin: the hook fired and captured the full payload (`tool_input.command`, `tool_response`, `cwd`).
2. Live e2e with this branch's schlock loaded: a nested session committed a `Co-Authored-By: Claude` trailer via `git commit -F msg.txt`, the hook flagged it, the model amended, and the final message was clean with exactly one commit.

The stale "Claude Code does not support PostToolUse hooks for plugins" claims in `CONTRIBUTING.md`, `docs/CONFIGURATION.md`, and `docs/ROADMAP.md` are corrected accordingly (the formatter feature is revivable, left unbuilt — no demand).

## Design decisions

- **Cheap gate**: substring `git` + `commit` (not the literal `"git commit"`) so global-option forms like `git -c core.pager=cat commit` still gate in. Precision is free downstream: the detector scans HEAD's actual message, so a false gate-pass costs one git subprocess and can never mis-flag a clean commit.
- **Freshness gate (30s)**: the Bash tool "succeeds" even when `git commit` is a no-op, so only a just-created HEAD is attributable to the triggering command — a failed re-run cannot re-flag a stale commit. 30s covers compound commands (`git commit -F f && make test`).
- **Amend-loop guard is structural**: the amend re-fires the hook; a clean message produces silence. A pathological trailer re-add is re-flagged — which is the correct response — and since the hook only informs (never blocks), no state is needed to bound it.
- **Fail-open everywhere**: any error, non-repo cwd, missing git → silent exit 0. Cosmetic filter, not a security boundary. Detections are recorded in the audit log (`decision: warn`).
- **Perf**: lazy-imports schlock only after the cheap gates pass; non-commit Bash calls pay only interpreter startup.
- **Known limit** (documented): the message is read from the session cwd, so `git -C /elsewhere commit` is not inspected.

## Also in this PR

`fix(types)` commit: the `basedpyright` pre-commit hook fails on a clean checkout (5 pre-existing errors in `rules.py`/`commit_filter.py`), blocking every commit for contributors with the tool installed. Fixed minimally: dropped an invalid re-annotation and added a fail-open None-guard consistent with `filter_commit_message`'s documented never-raises contract.

## Tests

16 new tests (`tests/test_post_tool_use.py`) against **real git repos** exercising the real delivery channels: trailer via `-F` file, via stdin heredoc, via `$(cat file)`; clean commit (no false positive); failed/no-op `git commit` against a backdated trailer-bearing HEAD (no stale re-flag); amend self-termination + pathological re-add; `git -c … commit` gating; cheap-gate subprocess-free assertion; garbage stdin.

Full suite: 2015 passed, 30 skipped (includes the 16 new). `ruff check` + `ruff format --check` + `basedpyright` clean.

