### PR TITLE
fix(parser): drop literal-suppression ranges inside ${...} spans (LAB-1584)

### DIFF
--- a/src/schlock/core/ast_view.py
+++ b/src/schlock/core/ast_view.py
@@ -503,6 +503,9 @@ class _Converter:
         if part_type not in _STRUCTURAL_WORD_PARTS:
             return []
         if part_type == "ParamExp":
+            # `_pos(part)` spans the WHOLE `${…}`, not just the parameter name:
+            # `extract_string_literals`' LAB-1584 filter needs it to CONTAIN the
+            # words spliced in below, or their quoted literals suppress rules.
             return [_node("ParamExp", _pos(part), value=part["Param"]["Value"]), *self._param_exp_words(part)]
         if part_type == "CmdSubst":
             inner = self.stmts_to_single_node(part.get("Stmts", []), "command substitution")

--- a/src/schlock/core/ast_view.py
+++ b/src/schlock/core/ast_view.py
@@ -538,6 +538,13 @@ class _Converter:
         The wrappers still convert first, so an unmappable word (escapes, ANSI-C
         quoting) keeps raising `UnmappedNodeError` → fallback tier.
 
+        Dropping the wrappers only closed the SHALLOW case: a quoted word NESTED
+        in the spliced subtree (`echo ${z:-$(echo "rm -rf /")}`) is a real word
+        node and registered a range all the same. That is fixed span-side, in
+        `extract_string_literals` — it discards any range strictly inside a
+        `parameter` span, which holds however deep this splices and however the
+        shape changes here (LAB-1584).
+
         `Length`/`Excl`/`Short`/`Names` are bare flags with no word payload, and
         `Exp.Op` selects WHEN the word is evaluated (`:-` vs `:=` vs `:?`), never
         what runs — so neither can shrink the danger surface by going unmapped.

--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -7,6 +7,7 @@ The parser is security-critical and REQUIRES bashlex for proper AST parsing.
 Regex-based parsing is explicitly NOT supported due to security risks.
 """
 
+import bisect
 import logging
 from typing import Any, Optional
 
@@ -732,13 +733,16 @@ class BashCommandParser:
             >>> # literals = [(6, 14)]  # Position of content inside quotes
         """
         string_literals: list[tuple] = []
-        expansion_spans: list[tuple] = []
+        parameter_spans: list[tuple] = []
 
         def visit(node):
             """Recursively visit AST nodes to find quoted strings."""
             if hasattr(node, "kind"):
+                # `parameter` ONLY — widening this to `commandsubstitution` would
+                # suppress every quoted literal inside `$(…)` on BOTH tiers, which
+                # is the under-block this filter exists to prevent.
                 if node.kind == "parameter" and hasattr(node, "pos"):
-                    expansion_spans.append(node.pos)
+                    parameter_spans.append(node.pos)
 
                 # Look for word nodes that are quoted strings
                 if node.kind == "word" and hasattr(node, "pos"):
@@ -766,11 +770,39 @@ class BashCommandParser:
         for node in ast_nodes or []:
             visit(node)
 
-        return [
-            (start, stop)
-            for start, stop in string_literals
-            if not any(exp_start < start and stop < exp_stop for exp_start, exp_stop in expansion_spans)
-        ]
+        if not parameter_spans:
+            return string_literals
+        return self._drop_ranges_inside(string_literals, parameter_spans)
+
+    @staticmethod
+    def _drop_ranges_inside(ranges: list[tuple], spans: list[tuple]) -> list[tuple]:
+        """Ranges from `ranges` lying STRICTLY inside no span — see `extract_string_literals`.
+
+        The naive `any(...)` scan is O(ranges x spans), and this runs twice per
+        validation (whole command, then again per segment) on a hook that fires
+        before every bash call — 43KB of `"a" … $v1 …` padding costs the caller
+        nothing and measured 580ms per call, so the quadratic is a stall lever on
+        a security gate, not a micro-optimization.
+
+        AST spans NEST but never partially overlap, which makes the fast path
+        exact rather than approximate: a range strictly inside a nested span is
+        strictly inside that span's outermost ancestor too, so reducing to the
+        OUTERMOST spans drops no containment. Those are then pairwise disjoint and
+        sorted, so one bisect finds the only span that can contain a range.
+        """
+        outermost: list[tuple] = []
+        for start, stop in sorted(spans, key=lambda span: (span[0], -span[1])):
+            if not outermost or start >= outermost[-1][1]:
+                outermost.append((start, stop))
+        starts = [span[0] for span in outermost]
+
+        kept: list[tuple] = []
+        for start, stop in ranges:
+            index = bisect.bisect_right(starts, start) - 1
+            if index >= 0 and outermost[index][0] < start and stop < outermost[index][1]:
+                continue
+            kept.append((start, stop))
+        return kept
 
     def has_dangerous_constructs(self, ast_nodes: list[Any]) -> list[str]:
         """Detect dangerous shell constructs in AST.

--- a/src/schlock/core/parser.py
+++ b/src/schlock/core/parser.py
@@ -712,17 +712,34 @@ class BashCommandParser:
         Returns:
             List of (start_pos, end_pos) tuples for each quoted string literal
 
+        PARITY (LAB-1584): a range found STRICTLY INSIDE a `parameter` node's span
+        is discarded. Suppression ranges shrink the danger surface, so the native
+        tier must never derive one the bashlex tier would not — and bashlex's
+        `parameter` node is childless, so it derives none from inside `${…}` at
+        any depth. The native tier splices the words a `${…}` EVALUATES in beside
+        the parameter node (`AstView._param_exp_words`, so SubstitutionValidator
+        can see `${z:-$(curl evil)}`); without this filter the quoted words in
+        that spliced subtree would mask rule matches bashlex still catches, e.g.
+        `echo ${z:-$(echo "rm -rf /")}`. STRICTLY inside is the whole contract:
+        `echo "$x"` has word (5,9) → range (6,8) and parameter (6,8), a range
+        bashlex derives too, and equality keeps it. On the bashlex tier the filter
+        is a no-op — a childless node's span can contain no other node.
+
         Example:
             >>> parser = BashCommandParser()
             >>> ast = parser.parse('echo "rm -rf /"')
             >>> literals = parser.extract_string_literals('echo "rm -rf /"', ast)
             >>> # literals = [(6, 14)]  # Position of content inside quotes
         """
-        string_literals = []
+        string_literals: list[tuple] = []
+        expansion_spans: list[tuple] = []
 
         def visit(node):
             """Recursively visit AST nodes to find quoted strings."""
             if hasattr(node, "kind"):
+                if node.kind == "parameter" and hasattr(node, "pos"):
+                    expansion_spans.append(node.pos)
+
                 # Look for word nodes that are quoted strings
                 if node.kind == "word" and hasattr(node, "pos"):
                     start, end = node.pos
@@ -749,7 +766,11 @@ class BashCommandParser:
         for node in ast_nodes or []:
             visit(node)
 
-        return string_literals
+        return [
+            (start, stop)
+            for start, stop in string_literals
+            if not any(exp_start < start and stop < exp_stop for exp_start, exp_stop in expansion_spans)
+        ]
 
     def has_dangerous_constructs(self, ast_nodes: list[Any]) -> list[str]:
         """Detect dangerous shell constructs in AST.

--- a/tests/test_walker_parity.py
+++ b/tests/test_walker_parity.py
@@ -31,6 +31,7 @@ from schlock.core.ast_view import UnmappedNodeError
 from schlock.core.native_bridge import NativeBridge, NativeBridgeError, resolve_binary
 from schlock.core.parser import BashCommandParser
 from schlock.core.validator import _get_substitution_validator, clear_caches, validate_command
+from schlock.exceptions import ParseError
 
 CORPUS_PATH = Path(__file__).parent.parent / "tools" / "schlock-parse" / "testdata" / "corpus.json"
 
@@ -316,6 +317,77 @@ class TestParameterExpansionSubstitutions:
         # under-block direction (PR #137 review).
         command = 'echo ${z:-"rm -rf /"}'
         assert BashCommandParser().extract_string_literals(command, NativeBridge().parse(command)) == []
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo ${z:-$(echo "rm -rf /")}',  # default value
+            'echo ${z:=$(echo "rm -rf /")}',  # assign-default
+            'echo ${z/x/$(echo "rm -rf /")}',  # replacement
+            'echo ${z:$(echo "rm -rf /"):1}',  # substring offset
+            'echo ${a[$(echo "rm -rf /")]}',  # subscript
+            'echo ${z:-$(echo "a${y:-$(echo "rm -rf /")}b")}',  # two splices deep
+        ],
+    )
+    def test_nested_expansion_words_create_no_literal_suppression_ranges(self, command):
+        """Dropping the `word` wrappers only closed the SHALLOW case (LAB-1584).
+
+        A quoted word NESTED inside the spliced subtree is a genuine `word` node
+        with a quote-delimited span, so it registered a suppression range all the
+        same — `echo ${z:-$(echo "rm -rf /")}` derived `[(18, 26)]` on the native
+        tier against bashlex's `[]`. Suppression SHRINKS the danger surface, so
+        that is the under-block direction and it must be zero at every depth.
+        """
+        parser = BashCommandParser()
+        assert parser.extract_string_literals(command, NativeBridge().parse(command)) == []
+        assert parser.extract_string_literals(command, parser.parse(command)) == []
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "rm -rf /"',  # plain quoted argument
+            'echo $(echo "rm -rf /")',  # quoted word inside a plain $( )
+            'echo "${x:-rm -rf /}"',  # the expansion IS the quoted word
+            'echo "$x"',  # ditto, shortest form — span equality, not containment
+            'echo ${z:-$(rm -rf /)} "keep me"',  # sibling of an expansion
+        ],
+    )
+    def test_literal_suppression_outside_expansions_is_unchanged(self, command):
+        """The LAB-1584 filter drops ranges STRICTLY inside a `parameter` span only.
+
+        Equality must keep the range: `echo "$x"` has word (5, 9) → range (6, 8)
+        and parameter (6, 8), and bashlex derives that range too. Over-dropping
+        here would turn quoted data into false positives on both tiers.
+        """
+        parser = BashCommandParser()
+        assert parser.extract_string_literals(command, NativeBridge().parse(command)) == parser.extract_string_literals(
+            command, parser.parse(command)
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            '[[ -f "rm -rf /" ]]',
+            'a=("rm -rf /")',
+            'echo $(( "1" ))',
+        ],
+    )
+    def test_native_only_constructs_may_derive_literals_bashlex_never_sees(self, command):
+        """AC-3: the other native-only splice sites need no fix, and here is why.
+
+        `[[ ]]`, array elements and `$(( ))` all splice operand words the same
+        way, so the native tier does derive suppression ranges inside them — but
+        bashlex cannot parse any of the three at all, so there is no bashlex
+        verdict for a native suppression to under-cut. The ranges are also
+        CORRECT (a quoted test operand really is data). The parity contract binds
+        only where bashlex produces a verdict; this test pins the fail-closed
+        premise that argument rests on, so a bashlex upgrade that starts parsing
+        these constructs re-opens the question instead of silently diverging.
+        """
+        parser = BashCommandParser()
+        assert parser.extract_string_literals(command, NativeBridge().parse(command))
+        with pytest.raises(ParseError):
+            parser.parse(command)
 
 
 class TestDeepNestingRoutesToFallback:

--- a/tests/test_walker_parity.py
+++ b/tests/test_walker_parity.py
@@ -343,26 +343,31 @@ class TestParameterExpansionSubstitutions:
         assert parser.extract_string_literals(command, parser.parse(command)) == []
 
     @pytest.mark.parametrize(
-        "command",
+        ("command", "expected"),
         [
-            'echo "rm -rf /"',  # plain quoted argument
-            'echo $(echo "rm -rf /")',  # quoted word inside a plain $( )
-            'echo "${x:-rm -rf /}"',  # the expansion IS the quoted word
-            'echo "$x"',  # ditto, shortest form — span equality, not containment
-            'echo ${z:-$(rm -rf /)} "keep me"',  # sibling of an expansion
+            ('echo "rm -rf /"', [(6, 14)]),  # plain quoted argument
+            ('echo $(echo "rm -rf /")', [(13, 21)]),  # quoted word inside a plain $( )
+            ('echo "${x:-rm -rf /}"', [(6, 20)]),  # the expansion IS the quoted word
+            ('echo "$x"', [(6, 8)]),  # ditto, shortest form — span equality, not containment
+            ('echo ${z:-$(rm -rf /)} "keep me"', [(24, 31)]),  # sibling of an expansion
         ],
     )
-    def test_literal_suppression_outside_expansions_is_unchanged(self, command):
+    def test_literal_suppression_outside_expansions_is_unchanged(self, command, expected):
         """The LAB-1584 filter drops ranges STRICTLY inside a `parameter` span only.
 
         Equality must keep the range: `echo "$x"` has word (5, 9) → range (6, 8)
         and parameter (6, 8), and bashlex derives that range too. Over-dropping
         here would turn quoted data into false positives on both tiers.
+
+        ABSOLUTE expectations, not just a cross-tier compare: the filter runs on
+        BOTH tiers, so an over-drop moves them together and a native-vs-bashlex
+        assertion stays green through it. Relaxing `<` to `<=` is the mutant that
+        proves it — it empties `echo "$x"` on the bashlex tier that ships today,
+        and the equality-only form of this test never noticed (LAB-1584 panel).
         """
         parser = BashCommandParser()
-        assert parser.extract_string_literals(command, NativeBridge().parse(command)) == parser.extract_string_literals(
-            command, parser.parse(command)
-        )
+        assert parser.extract_string_literals(command, parser.parse(command)) == expected
+        assert parser.extract_string_literals(command, NativeBridge().parse(command)) == expected
 
     @pytest.mark.parametrize(
         "command",
@@ -412,13 +417,30 @@ class TestDeepNestingRoutesToFallback:
 
 @needs_binary
 class TestKnownBashlexUnderDecode:
-    """One divergence the sweep found where native is RIGHT and bashlex is wrong.
+    """Divergences the sweep found where native is RIGHT and bashlex is wrong.
 
-    Pinned so T3 inherits it, and so a bashlex upgrade that changes the fallback
-    tier's decode trips a test. Safe to diverge: the mangling needs an adjacent
-    literal, so the mangled word always carries that literal too and can never
-    collapse to a bare dangerous command.
+    Pinned so T3 inherits them, and so a bashlex upgrade that changes the
+    fallback tier's decode trips a test. Safe to diverge: the mangling needs an
+    adjacent literal, so the mangled word always carries that literal too and can
+    never collapse to a bare dangerous command.
     """
+
+    def test_nested_expansion_span_stops_at_the_first_brace(self):
+        """bashlex's `parameter` span ends at the first `}` when `${…}` nests.
+
+        So the trailing substitution of `${x/${y}/`…`}` falls OUTSIDE bashlex's
+        parameter span and keeps its suppression range, while native's ParamExp
+        span covers the whole construct and the LAB-1584 filter drops it. Native
+        suppresses LESS, i.e. blocks MORE — the superset direction, so the parity
+        contract holds and no fix is owed. Pinned because it is a native-side
+        FALSE POSITIVE the day T8/LAB-532 wires the native tier in, and whoever
+        meets it there should find it documented rather than read it as a
+        regression (LAB-1584 panel).
+        """
+        parser = BashCommandParser()
+        command = 'echo ${x/${y}/`echo "lit"`}'
+        assert parser.extract_string_literals(command, parser.parse(command)) == [(21, 24)]
+        assert parser.extract_string_literals(command, NativeBridge().parse(command)) == []
 
     def test_single_quotes_concatenated_with_a_literal(self):
         # bash's value for `'a"b'x` is `a"bx`; bashlex drops the inner quotes


### PR DESCRIPTION
Closes LAB-1584.

**Stacked on [#137](https://github.com/27Bslash6/schlock/pull/137)** (base `lab-912-walker-parity-parse-once`) — the `_param_exp_words` code this fixes only exists there. Retarget to `main` once [#137](https://github.com/27Bslash6/schlock/pull/137) merges.

## The bug

The native tier splices the words a `${…}` expansion EVALUATES in beside the `parameter` node (`AstView._param_exp_words`) so `SubstitutionValidator` can see `${z:-$(curl evil)}`. Quoted words **nested** in that spliced subtree are real `word` nodes with quote-delimited spans, so they registered quoted-literal suppression ranges that bashlex — whose `parameter` node is childless — never derives:

| command | native | bashlex |
|---|---|---|
| `echo ${z:-$(echo "rm -rf /")}` | `[(18, 26)]` | `[]` |

Suppression **shrinks** the danger surface, so this is the under-block direction and it violates the parity contract (native ⊇ bashlex). [#137](https://github.com/27Bslash6/schlock/pull/137)'s `word.parts` flatten closed only the shallow wrapper case.

## The fix

Span-side, not shape-side: `extract_string_literals` discards any range **strictly** inside a `parameter` span. bashlex's `parameter` is childless so it derives none from inside `${…}` at any depth, which makes the filter a provable — and measured — no-op on the fallback tier. Stating the invariant in bashlex vocabulary at the derivation site keeps it true however `_param_exp_words` reshapes its splice, and leaves the sibling shape the LAB-912 panel chose untouched.

**STRICTLY inside is the whole contract.** `echo "$x"` has word `(5, 9)` → range `(6, 8)` and parameter `(6, 8)`; bashlex derives that range too, so equality keeps it. Over-dropping would turn quoted data into false positives on both tiers — and `validate_command` runs the **bashlex** tier today, so that would be a live regression, not a latent one.

## Expert-panel review

Ran at high stakes (bug-hunter-supreme, security-specialist, code-craftsman, catchphrase-agent). Both majors below were converged on independently by two agents and reproduced before fixing — second commit.

- **Tests passed under a `<` → `<=` mutation.** They asserted native == bashlex and native == `[]`; the filter runs on both tiers, so an over-drop moved them together and stayed green. The mutant empties `echo "$x"` on the shipping bashlex tier. Fixed with absolute per-case expectations asserted against both tiers; the mutation now fails two cases.
- **The `any(...)` scan was O(ranges × parameters)** on a hook that runs before every bash call, twice per validation. Measured 4× length → 70× time; 43KB of `"a" … $v1 …` padding cost 580ms. Replaced with sort + bisect — **exact**, not approximate: AST spans nest but never partially overlap, so reducing to outermost spans drops no containment and those are then disjoint. 43KB now 7ms (83×); 87KB is 15ms.
- `expansion_spans` → `parameter_spans` (the old name invites adding `commandsubstitution`, which would suppress every quoted literal inside `$(…)` on both tiers).
- Comment at the `ParamExp` construction: `_pos(part)` must span the whole `${…}` because the filter needs it to contain the splice.
- New `TestKnownBashlexUnderDecode` case: bashlex's `parameter` span stops at the first `}` when `${…}` nests, so `` echo ${x/${y}/`echo "lit"`} `` keeps a range native drops. Native suppresses less (blocks more) — superset direction, nothing owed — pinned because it becomes a native-side false positive at T8/LAB-532.

**Not applied:** dropping `hasattr(node, "pos")` on the parameter branch (mirrors the adjacent pre-existing word branch at zero cost; `extract_string_literals` takes arbitrary walker nodes).

**Out of scope, filed separately:** the panel's security agent found two pre-existing under-blocks that reproduce identically on parent `b4744f2` — they are not caused by this change and are not fixed here.

## Verification

- AC-1: `extract_string_literals` returns `[]` for `echo ${z:-$(echo "rm -rf /")}` on both tiers.
- AC-2/AC-3: 15 new cases in `tests/test_walker_parity.py`. The 6 nested cases fail on pre-fix code; the 5 control cases pass pre-fix (so they are not tautological). AC-3's other splice sites (`[[ ]]`, arrays, `$(( ))`) are covered by a test that pins bashlex's fail-closed `ParseError` — the premise the "no fix owed there" argument rests on.
- AC-4: LAB-912 harvested-command sweep re-run — 3830 commands comparable on both tiers, 4273 segments, all four walkers + `validate_all_substitutions`: **0** native-only suppression ranges (was 12), **0** weaker substitution verdicts.
- AC-6: `ruff check` clean, `ruff format --check` clean, **2212 passed** (`-m "not slow"`).
